### PR TITLE
Add research storage paths and CRM attachment base URL settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,11 @@ All configuration is driven through environment variables or a `.env` file. The 
 | Polling windows | `CAL_LOOKAHEAD_DAYS`, `CAL_LOOKBACK_DAYS` | Control how far ahead/behind to query events. |
 | LLM guardrails | `LLM_CONFIDENCE_THRESHOLD_*`, `LLM_COST_CAP_*`, `LLM_RETRY_BUDGET_*` | Tune prompt behaviour and spending limits. |
 | Compliance | `COMPLIANCE_MODE`, `MASK_PII_IN_LOGS`, `MASK_PII_IN_MESSAGES`, `PII_FIELD_WHITELIST` | Define masking policies and audit posture. |
-| Storage | `LOG_STORAGE_DIR`, `EVENT_LOG_DIR`, `WORKFLOW_LOG_DIR`, `RUN_LOG_DIR` | Choose where structured artefacts are written. |
+| Storage | `LOG_STORAGE_DIR`, `EVENT_LOG_DIR`, `WORKFLOW_LOG_DIR`, `RUN_LOG_DIR`, `AGENT_LOG_DIR`, `RESEARCH_ARTIFACT_DIR`, `RESEARCH_PDF_DIR` | Choose where structured artefacts, research notes, and supporting files are written. |
+| CRM attachments | `CRM_ATTACHMENT_BASE_URL` | Prefix CRM-friendly links to stored dossiers and artefacts. |
 | Agent overrides | `POLLING_AGENT`, `TRIGGER_AGENT`, `EXTRACTION_AGENT`, `HUMAN_AGENT`, `CRM_AGENT` | Swap default implementations via the agent factory. |
 
-The configuration reference includes additional options for rate limits, cost caps, and structured YAML overrides when using `AGENT_CONFIG_FILE`.
+The configuration reference includes additional options for rate limits, cost caps, structured YAML overrides when using `AGENT_CONFIG_FILE`, plus controls for research artefact storage and CRM attachment link construction.
 
 ## Running the orchestrator
 

--- a/config/README.md
+++ b/config/README.md
@@ -21,6 +21,10 @@ to poll events.
 | `EVENT_LOG_DIR` | Override for event log storage (defaults to a subdirectory of `LOG_STORAGE_DIR`). | `<LOG_STORAGE_DIR>/events` |
 | `WORKFLOW_LOG_DIR` | Override for workflow log storage. | `<LOG_STORAGE_DIR>/workflows` |
 | `RUN_LOG_DIR` | Override for per-run log files. | `<LOG_STORAGE_DIR>/runs` |
+| `AGENT_LOG_DIR` | Directory where per-agent operational logs are written. | `<LOG_STORAGE_DIR>/agents` |
+| `RESEARCH_ARTIFACT_DIR` | Folder for storing structured research outputs and notes. | `<LOG_STORAGE_DIR>/research/artifacts` |
+| `RESEARCH_PDF_DIR` | Folder for saving downloaded research PDFs. | `<LOG_STORAGE_DIR>/research/pdfs` |
+| `CRM_ATTACHMENT_BASE_URL` | Base URL used when constructing CRM attachment links. | empty |
 | `COMPLIANCE_MODE` | Controls default masking rules; accepts `standard` or `strict`. | `standard` |
 | `MASK_PII_IN_LOGS` | Explicit toggle to mask personal data in logs regardless of compliance mode. | `true` |
 | `MASK_PII_IN_MESSAGES` | Explicit toggle to mask personal data in HITL messages. | `false` (`true` when `COMPLIANCE_MODE=strict`) |
@@ -74,6 +78,18 @@ llm:
 When watchdog is available, the application monitors the `.env` file and the optional YAML/JSON
 configuration for changes. Updates are applied live to the running `MasterWorkflowAgent` and any
 other consumer of `settings`, avoiding the need to restart long-lived processes.
+
+### Research artefacts and CRM attachments
+
+Research agents persist their intermediate outputs alongside workflow logs to aid audits and
+follow-up work. By default, structured artefacts and downloaded PDFs live within the
+`log_storage/run_history/research` tree, mirroring the existing log directory layout. Override the
+`RESEARCH_ARTIFACT_DIR` and `RESEARCH_PDF_DIR` variables to relocate these stores when mounting
+network volumes or long-term archives.
+
+The CRM dispatcher can expose hosted artefacts through stable links. Set
+`CRM_ATTACHMENT_BASE_URL` to the prefix your CRM expects (for example, an S3 bucket URL) so
+generated messages reference the correct attachment location.
 
 ### Compliance modes and masking
 

--- a/config/config.py
+++ b/config/config.py
@@ -219,6 +219,12 @@ class Settings:
             "RUN_LOG_DIR", self.log_storage_dir / "runs"
         )
 
+        self.agent_log_dir: Path
+        self.research_artifact_dir: Path
+        self.research_pdf_dir: Path
+        self.crm_attachment_base_url: str
+        self._load_storage_extensions()
+
         self.prompt_directory: Path = _get_path_env(
             "PROMPT_DIRECTORY", project_root / "templates" / "prompts"
         )
@@ -372,6 +378,21 @@ class Settings:
 
         self.prompt_versions = prompt_versions
 
+    def _load_storage_extensions(self) -> None:
+        """Load optional storage-related settings from environment variables."""
+
+        self.agent_log_dir = _get_path_env("AGENT_LOG_DIR", self.log_storage_dir / "agents")
+
+        research_root = self.log_storage_dir / "research"
+        self.research_artifact_dir = _get_path_env(
+            "RESEARCH_ARTIFACT_DIR", research_root / "artifacts"
+        )
+        self.research_pdf_dir = _get_path_env(
+            "RESEARCH_PDF_DIR", research_root / "pdfs"
+        )
+
+        self.crm_attachment_base_url = _get_env_var("CRM_ATTACHMENT_BASE_URL") or ""
+
     def refresh_llm_configuration(self) -> None:
         """Reload LLM configuration from the configured sources."""
 
@@ -387,6 +408,7 @@ class Settings:
         else:
             self._raw_agent_config = {}
 
+        self._load_storage_extensions()
         self._load_llm_configuration(self._raw_agent_config)
         self._load_prompt_configuration(self._raw_agent_config)
 

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -41,6 +41,51 @@ def test_log_storage_dir_respects_env(monkeypatch, tmp_path):
     assert settings.event_log_dir == (target / "events").resolve()
 
 
+def test_research_and_agent_paths_default(monkeypatch):
+    monkeypatch.setenv("SETTINGS_SKIP_DOTENV", "1")
+    for key in [
+        "AGENT_LOG_DIR",
+        "RESEARCH_ARTIFACT_DIR",
+        "RESEARCH_PDF_DIR",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+
+    settings = reload_settings()
+
+    base = Path(__file__).resolve().parents[1] / "log_storage" / "run_history"
+    assert settings.agent_log_dir == base / "agents"
+    assert settings.research_artifact_dir == base / "research" / "artifacts"
+    assert settings.research_pdf_dir == base / "research" / "pdfs"
+
+
+def test_research_and_agent_paths_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("SETTINGS_SKIP_DOTENV", "1")
+    monkeypatch.setenv("AGENT_LOG_DIR", str(tmp_path / "agents"))
+    monkeypatch.setenv("RESEARCH_ARTIFACT_DIR", str(tmp_path / "research" / "artifacts"))
+    monkeypatch.setenv("RESEARCH_PDF_DIR", str(tmp_path / "research" / "pdfs"))
+
+    settings = reload_settings()
+
+    assert settings.agent_log_dir == (tmp_path / "agents").resolve()
+    assert settings.research_artifact_dir == (tmp_path / "research" / "artifacts").resolve()
+    assert settings.research_pdf_dir == (tmp_path / "research" / "pdfs").resolve()
+
+
+def test_crm_attachment_base_url(monkeypatch):
+    monkeypatch.setenv("SETTINGS_SKIP_DOTENV", "1")
+    monkeypatch.delenv("CRM_ATTACHMENT_BASE_URL", raising=False)
+
+    settings = reload_settings()
+    assert settings.crm_attachment_base_url == ""
+
+    monkeypatch.setenv("CRM_ATTACHMENT_BASE_URL", "https://crm.example.com/attachments/")
+    settings = reload_settings()
+    assert (
+        settings.crm_attachment_base_url
+        == "https://crm.example.com/attachments/"
+    )
+
+
 def test_compliance_defaults(monkeypatch):
     monkeypatch.setenv("SETTINGS_SKIP_DOTENV", "1")
     monkeypatch.delenv("COMPLIANCE_MODE", raising=False)


### PR DESCRIPTION
## Summary
- add research storage, agent log, and CRM attachment configuration fields to the shared Settings object
- document the new environment variables in both configuration references with guidance on usage
- extend configuration tests to cover the new defaults and environment overrides

## Testing
- `pytest tests/test_config_settings.py`


------
https://chatgpt.com/codex/tasks/task_e_68da8cd5d218832bbbed4dd3c233afb2