### PR TITLE
Add HubSpot CRM integration module

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -219,6 +219,17 @@ class Settings:
             "RUN_LOG_DIR", self.log_storage_dir / "runs"
         )
 
+        self.hubspot_access_token: Optional[str] = _get_env_var("HUBSPOT_ACCESS_TOKEN")
+        self.hubspot_client_secret: Optional[str] = _get_env_var("HUBSPOT_CLIENT_SECRET")
+        self.hubspot_api_base_url: str = _get_env_var("HUBSPOT_API_BASE_URL") or (
+            "https://api.hubapi.com"
+        )
+        self.hubspot_request_timeout: int = _get_int_env("HUBSPOT_REQUEST_TIMEOUT", 10)
+        self.hubspot_max_retries: int = _get_int_env("HUBSPOT_MAX_RETRIES", 3)
+        self.hubspot_retry_backoff_seconds: float = _get_float_env(
+            "HUBSPOT_RETRY_BACKOFF_SECONDS", 1.0
+        )
+
         self.agent_log_dir: Path
         self.research_artifact_dir: Path
         self.research_pdf_dir: Path

--- a/integration/hubspot_integration.py
+++ b/integration/hubspot_integration.py
@@ -220,4 +220,3 @@ class HubSpotIntegration:
                 if value:
                     return normalize_text(value)
         return ""
-

--- a/integration/hubspot_integration.py
+++ b/integration/hubspot_integration.py
@@ -1,0 +1,223 @@
+"""HubSpot CRM integration helpers for company lookup workflows."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Sequence
+from urllib import request
+from urllib.error import HTTPError, URLError
+
+from config.config import Settings
+from utils.text_normalization import normalize_text
+
+
+@dataclass
+class HubSpotConfig:
+    """Runtime configuration for :class:`HubSpotIntegration`."""
+
+    access_token: str
+    client_secret: Optional[str]
+    api_base_url: str
+    request_timeout: int
+    max_retries: int
+    retry_backoff_seconds: float
+
+
+class HubSpotIntegration:
+    """Wrapper around HubSpot's CRM API for company discovery."""
+
+    SEARCH_PATH: str = "/crm/v3/objects/companies/search"
+
+    def __init__(
+        self,
+        *,
+        settings: Optional[Settings] = None,
+        access_token: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        api_base_url: Optional[str] = None,
+        request_timeout: Optional[int] = None,
+        max_retries: Optional[int] = None,
+        retry_backoff_seconds: Optional[float] = None,
+    ) -> None:
+        runtime_settings = settings or Settings()
+
+        resolved_access_token = access_token or runtime_settings.hubspot_access_token
+        if not resolved_access_token:
+            raise EnvironmentError("HubSpot access token is not configured.")
+
+        resolved_base_url = api_base_url or runtime_settings.hubspot_api_base_url
+        if not resolved_base_url:
+            raise EnvironmentError("HubSpot API base URL is not configured.")
+
+        resolved_timeout = request_timeout or runtime_settings.hubspot_request_timeout
+        resolved_retries = max_retries or runtime_settings.hubspot_max_retries
+        resolved_backoff = (
+            retry_backoff_seconds or runtime_settings.hubspot_retry_backoff_seconds
+        )
+
+        self._config = HubSpotConfig(
+            access_token=resolved_access_token,
+            client_secret=client_secret or runtime_settings.hubspot_client_secret,
+            api_base_url=resolved_base_url.rstrip("/"),
+            request_timeout=resolved_timeout,
+            max_retries=max(1, resolved_retries),
+            retry_backoff_seconds=max(0.0, resolved_backoff),
+        )
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def find_company_by_domain(
+        self,
+        domain: str,
+        *,
+        properties: Optional[Sequence[str]] = None,
+    ) -> Optional[Dict[str, object]]:
+        """Return the HubSpot company that owns ``domain`` if available."""
+
+        normalised_input = normalize_text(domain)
+        normalised_domain = self._normalise_domain(normalised_input)
+        if not normalised_domain:
+            return None
+
+        payload = {
+            "filterGroups": [
+                {
+                    "filters": [
+                        {
+                            "propertyName": "domain",
+                            "operator": "EQ",
+                            "value": normalised_domain,
+                        }
+                    ]
+                }
+            ],
+            "limit": 5,
+        }
+
+        if properties:
+            payload["properties"] = list(properties)
+
+        response_payload = self._post(self.SEARCH_PATH, payload)
+        results: Iterable[Dict[str, object]] = response_payload.get("results", [])
+
+        for company in results:
+            domain_value = self._extract_domain(company)
+            if domain_value and self._normalise_domain(domain_value) == normalised_domain:
+                return company
+
+        return next(iter(results), None)
+
+    def list_similar_companies(
+        self,
+        company_name: str,
+        *,
+        limit: int = 5,
+        properties: Optional[Sequence[str]] = None,
+    ) -> List[Dict[str, object]]:
+        """Return companies whose names resemble ``company_name``."""
+
+        normalised_name = normalize_text(company_name)
+        if not normalised_name:
+            return []
+
+        payload = {
+            "filterGroups": [
+                {
+                    "filters": [
+                        {
+                            "propertyName": "name",
+                            "operator": "CONTAINS_TOKEN",
+                            "value": normalised_name,
+                        }
+                    ]
+                }
+            ],
+            "limit": max(1, limit),
+        }
+
+        if properties:
+            payload["properties"] = list(properties)
+
+        response_payload = self._post(self.SEARCH_PATH, payload)
+        results: Iterable[Dict[str, object]] = response_payload.get("results", [])
+        return list(results)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _post(self, path: str, payload: Dict[str, object]) -> Dict[str, object]:
+        url = f"{self._config.api_base_url}{path}"
+        body = json.dumps(payload).encode("utf-8")
+        headers = {
+            "Authorization": f"Bearer {self._config.access_token}",
+            "Content-Type": "application/json",
+        }
+
+        req = request.Request(url, data=body, headers=headers, method="POST")
+
+        for attempt in range(1, self._config.max_retries + 1):
+            try:
+                logging.info(
+                    "HubSpot API request",
+                    extra={
+                        "method": "POST",
+                        "url": url,
+                        "attempt": attempt,
+                    },
+                )
+            except TypeError:
+                logging.info("HubSpot API request %s %s (attempt %d)", "POST", url, attempt)
+
+            try:
+                with request.urlopen(req, timeout=self._config.request_timeout) as resp:
+                    raw = resp.read()
+                    return json.loads(raw.decode("utf-8")) if raw else {}
+            except HTTPError as exc:
+                logging.error(
+                    "HubSpot API responded with HTTP error: %s",
+                    exc,
+                )
+                if attempt == self._config.max_retries:
+                    raise
+            except URLError as exc:
+                logging.error("Unable to reach HubSpot API: %s", exc)
+                if attempt == self._config.max_retries:
+                    raise
+
+            self._backoff(attempt)
+
+        return {}
+
+    def _backoff(self, attempt: int) -> None:
+        delay = self._config.retry_backoff_seconds * (2 ** (attempt - 1))
+        if delay > 0:
+            time.sleep(delay)
+
+    @staticmethod
+    def _normalise_domain(value: str) -> str:
+        text = normalize_text(value)
+        if not text:
+            return ""
+
+        stripped = text
+        if "//" in stripped:
+            stripped = stripped.split("//", 1)[1]
+        stripped = stripped.split("/", 1)[0]
+        if stripped.startswith("www."):
+            stripped = stripped[4:]
+        return stripped
+
+    @staticmethod
+    def _extract_domain(company: Dict[str, object]) -> str:
+        properties = company.get("properties") if isinstance(company, dict) else None
+        if isinstance(properties, dict):
+            for key in ("domain", "website"):
+                value = properties.get(key)
+                if value:
+                    return normalize_text(value)
+        return ""
+

--- a/tests/integration/test_hubspot_integration.py
+++ b/tests/integration/test_hubspot_integration.py
@@ -1,0 +1,135 @@
+import json
+from io import BytesIO
+from typing import List
+from urllib.error import URLError
+
+import pytest
+
+from config.config import Settings
+from integration.hubspot_integration import HubSpotIntegration
+
+
+class FakeResponse(BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
+        return False
+
+
+@pytest.fixture(autouse=True)
+def clear_settings_cache(monkeypatch):
+    # Ensure a clean environment for each test case.
+    monkeypatch.delenv("HUBSPOT_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("HUBSPOT_CLIENT_SECRET", raising=False)
+    monkeypatch.delenv("HUBSPOT_API_BASE_URL", raising=False)
+    monkeypatch.delenv("HUBSPOT_REQUEST_TIMEOUT", raising=False)
+    monkeypatch.delenv("HUBSPOT_MAX_RETRIES", raising=False)
+    monkeypatch.delenv("HUBSPOT_RETRY_BACKOFF_SECONDS", raising=False)
+
+
+@pytest.fixture
+def configured_settings(monkeypatch) -> Settings:
+    monkeypatch.setenv("HUBSPOT_ACCESS_TOKEN", "token-123")
+    monkeypatch.setenv("HUBSPOT_CLIENT_SECRET", "secret-xyz")
+    monkeypatch.setenv("HUBSPOT_API_BASE_URL", "https://api.test.local")
+    monkeypatch.setenv("HUBSPOT_REQUEST_TIMEOUT", "5")
+    monkeypatch.setenv("HUBSPOT_MAX_RETRIES", "3")
+    monkeypatch.setenv("HUBSPOT_RETRY_BACKOFF_SECONDS", "0")
+    # Recreate Settings so new environment values are used.
+    return Settings()
+
+
+def test_find_company_by_domain_normalizes_and_matches(monkeypatch, configured_settings):
+    integration = HubSpotIntegration(settings=configured_settings)
+
+    captured_payloads: List[dict] = []
+
+    response_payload = {
+        "results": [
+            {
+                "id": "1",
+                "properties": {"domain": "Example.COM", "name": "Example"},
+            }
+        ]
+    }
+
+    def fake_urlopen(req, timeout):
+        assert timeout == configured_settings.hubspot_request_timeout
+        assert req.full_url == "https://api.test.local/crm/v3/objects/companies/search"
+        assert req.headers["Authorization"] == "Bearer token-123"
+        payload = json.loads(req.data.decode("utf-8"))
+        captured_payloads.append(payload)
+        filters = payload["filterGroups"][0]["filters"][0]
+        assert filters["value"] == "example.com"
+        return FakeResponse(json.dumps(response_payload).encode("utf-8"))
+
+    monkeypatch.setattr(
+        "integration.hubspot_integration.request.urlopen",
+        fake_urlopen,
+    )
+
+    result = integration.find_company_by_domain("HTTPS://Example.com/")
+
+    assert result == response_payload["results"][0]
+    assert captured_payloads, "Expected HubSpot request payload to be captured"
+
+
+def test_list_similar_companies_uses_normalized_name(monkeypatch, configured_settings):
+    integration = HubSpotIntegration(settings=configured_settings)
+
+    response_payload = {
+        "results": [
+            {"id": "1", "properties": {"name": "Acme Corp"}},
+            {"id": "2", "properties": {"name": "The ACME Corporation"}},
+        ]
+    }
+
+    def fake_urlopen(req, timeout):
+        payload = json.loads(req.data.decode("utf-8"))
+        filters = payload["filterGroups"][0]["filters"][0]
+        assert filters["value"] == "acme corporation"
+        return FakeResponse(json.dumps(response_payload).encode("utf-8"))
+
+    monkeypatch.setattr(
+        "integration.hubspot_integration.request.urlopen",
+        fake_urlopen,
+    )
+
+    companies = integration.list_similar_companies(" Acme Corporation ")
+
+    assert len(companies) == 2
+    assert companies[0]["id"] == "1"
+
+
+def test_retry_logic_recovers_from_transient_error(monkeypatch, configured_settings):
+    integration = HubSpotIntegration(settings=configured_settings)
+
+    attempts = {"count": 0}
+
+    response_payload = {"results": []}
+
+    def fake_urlopen(req, timeout):
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise URLError("temporary outage")
+        return FakeResponse(json.dumps(response_payload).encode("utf-8"))
+
+    monkeypatch.setattr(
+        "integration.hubspot_integration.request.urlopen",
+        fake_urlopen,
+    )
+
+    companies = integration.list_similar_companies("Example")
+
+    assert companies == []
+    assert attempts["count"] == 2
+
+
+def test_missing_access_token_raises_error(monkeypatch):
+    monkeypatch.delenv("HUBSPOT_ACCESS_TOKEN", raising=False)
+
+    with pytest.raises(EnvironmentError):
+        HubSpotIntegration(settings=Settings())
+

--- a/tests/integration/test_hubspot_integration.py
+++ b/tests/integration/test_hubspot_integration.py
@@ -132,4 +132,3 @@ def test_missing_access_token_raises_error(monkeypatch):
 
     with pytest.raises(EnvironmentError):
         HubSpotIntegration(settings=Settings())
-


### PR DESCRIPTION
## Summary
- add configuration entries to surface HubSpot credentials, base URL, and retry settings via `Settings`
- implement a reusable `HubSpotIntegration` module that normalizes inputs, handles retries, and fetches companies
- add integration tests that simulate API responses to verify normalization, lookups, and retry behaviour

## Testing
- pytest tests/integration/test_hubspot_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68daa63448d0832b8a3ece37fbb9b484