### PR TITLE
feat: support dossier attachments and reporting PDFs

### DIFF
--- a/agents/email_agent.py
+++ b/agents/email_agent.py
@@ -1,7 +1,10 @@
-import smtplib
-from email.mime.text import MIMEText
-from email.mime.multipart import MIMEMultipart
 import logging
+import smtplib
+from email.mime.application import MIMEApplication
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from pathlib import Path
+from typing import Iterable, Optional, Sequence, Union
 
 
 class EmailAgent:
@@ -17,20 +20,36 @@ class EmailAgent:
         self.password = password
         self.sender_email = sender_email
 
-    def send_email(self, recipient, subject, body, html_body=None):
+    def send_email(
+        self,
+        recipient,
+        subject,
+        body,
+        html_body=None,
+        *,
+        attachments: Optional[Sequence[Union[str, Path]]] = None,
+        attachment_links: Optional[Iterable[str]] = None,
+    ):
         """
         Sends an email. Optionally, an HTML body can be provided.
         """
-        msg = MIMEMultipart("alternative")
+        msg = MIMEMultipart()
         msg["From"] = self.sender_email
         msg["To"] = recipient
         msg["Subject"] = subject
 
-        part1 = MIMEText(body, "plain")
-        msg.attach(part1)
+        normalized_links = self._normalize_links(attachment_links)
+        text_body = self._augment_plain_body(body, normalized_links)
+        html_body = self._augment_html_body(html_body, normalized_links)
+
+        alternative_part = MIMEMultipart("alternative")
+        alternative_part.attach(MIMEText(text_body, "plain"))
         if html_body:
-            part2 = MIMEText(html_body, "html")
-            msg.attach(part2)
+            alternative_part.attach(MIMEText(html_body, "html"))
+        msg.attach(alternative_part)
+
+        for attachment_part in self._build_attachments(attachments):
+            msg.attach(attachment_part)
 
         try:
             with smtplib.SMTP_SSL(self.smtp_server, self.smtp_port) as server:
@@ -41,6 +60,64 @@ class EmailAgent:
         except Exception as e:
             logging.error(f"Failed to send email to {recipient}: {e}")
             return False
+
+    def _normalize_links(self, links: Optional[Iterable[str]]) -> Sequence[str]:
+        if not links:
+            return []
+        normalized = []
+        for link in links:
+            if not link:
+                continue
+            normalized.append(str(link).strip())
+        return normalized
+
+    def _augment_plain_body(self, body: str, links: Sequence[str]) -> str:
+        if not links:
+            return body
+        clean_body = body.rstrip()
+        link_lines = ["", "", "Access the dossier using the following link(s):"]
+        link_lines.extend(f"- {link}" for link in links)
+        return clean_body + "\n".join(link_lines) + "\n"
+
+    def _augment_html_body(
+        self, html_body: Optional[str], links: Sequence[str]
+    ) -> Optional[str]:
+        if not links or html_body is None:
+            return html_body
+        link_items = "".join(
+            f'<li><a href="{link}">{link}</a></li>' for link in links
+        )
+        link_block = (
+            "<hr><p>Access the dossier using the following link(s):</p>"
+            f"<ul>{link_items}</ul>"
+        )
+        if "</body>" in html_body:
+            return html_body.replace("</body>", f"{link_block}</body>")
+        return html_body + link_block
+
+    def _build_attachments(
+        self, attachments: Optional[Sequence[Union[str, Path]]]
+    ) -> Sequence[MIMEApplication]:
+        prepared: list[MIMEApplication] = []
+        if not attachments:
+            return prepared
+
+        for attachment in attachments:
+            if attachment is None:
+                continue
+            path = Path(attachment)
+            try:
+                data = path.read_bytes()
+            except OSError as exc:
+                logging.error("Unable to read attachment %s: %s", path, exc)
+                continue
+
+            part = MIMEApplication(
+                data, _subtype=path.suffix.lstrip(".") or "octet-stream"
+            )
+            part.add_header("Content-Disposition", "attachment", filename=path.name)
+            prepared.append(part)
+        return prepared
 
 
 # Example usage:

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ orjson>=3.9,<4.0              # Fast JSON (optional, for performance)
 
 # Data manipulation
 pandas>=2.2,<3.0              # For any advanced data processing, reporting, or enrichment
+reportlab>=3.6,<4.0           # Generate PDF summaries for research outputs
 
 # Logging and monitoring
 loguru>=0.7,<1.0              # Modern, flexible logging (optional, enhances standard logging)

--- a/templates/email/final_research_delivery.html
+++ b/templates/email/final_research_delivery.html
@@ -1,0 +1,8 @@
+<p>Hi {recipient_name},</p>
+<p>Thank you for your patience. We've completed the research for <strong>{company_name}</strong>.<br>
+Attached you'll find the final dossier along with any supporting materials requested.</p>
+<p><strong>Key highlights:</strong><br>
+{highlights}</p>
+<p>If you prefer to review the dossier in the CRM portal, use the link below.</p>
+<p>Please let us know if you have any follow-up questions or additional requests.</p>
+{signature}

--- a/templates/email/final_research_delivery.txt
+++ b/templates/email/final_research_delivery.txt
@@ -1,0 +1,13 @@
+Hi {recipient_name},
+
+Thank you for your patience. We've completed the research for {company_name}.
+Attached you'll find the final dossier along with any supporting materials requested.
+
+Key highlights:
+{highlights}
+
+If you prefer to review the dossier in the CRM portal, use the link below.
+
+Please let us know if you have any follow-up questions or additional requests.
+
+{signature}

--- a/templates/email/internal_research_existing_dossier.html
+++ b/templates/email/internal_research_existing_dossier.html
@@ -1,0 +1,7 @@
+<p>Hi {recipient_name},</p>
+<p>We already have a dossier for <strong>{company_name}</strong>.<br>
+The latest version was generated on <strong>{last_report_date}</strong>.</p>
+<p>Use the link below to open the dossier in the CRM attachment portal.</p>
+<p>Reply with <em>I USE THE EXISTING</em> if the current dossier works for you.<br>
+Reply with <em>NEW REPORT</em> if you need an updated dossier.</p>
+{signature}

--- a/templates/email/internal_research_existing_dossier.txt
+++ b/templates/email/internal_research_existing_dossier.txt
@@ -1,0 +1,11 @@
+Hi {recipient_name},
+
+We already have a dossier for {company_name}.
+The latest version was generated on {last_report_date}.
+
+Use the link below to open the dossier in the CRM attachment portal.
+
+Reply with I USE THE EXISTING if the current dossier works for you.
+Reply with NEW REPORT if you need an updated dossier.
+
+{signature}

--- a/templates/email_templates.md
+++ b/templates/email_templates.md
@@ -1,0 +1,25 @@
+# Email Templates
+
+This directory stores reusable communication snippets shared across agents.
+
+## Internal research: existing dossier notification
+- **Text template:** `templates/email/internal_research_existing_dossier.txt`
+- **HTML template:** `templates/email/internal_research_existing_dossier.html`
+- **Purpose:** informs requestors that a dossier already exists and provides a portal link back to the CRM attachment.
+
+## Internal research: final research delivery
+- **Text template:** `templates/email/final_research_delivery.txt`
+- **HTML template:** `templates/email/final_research_delivery.html`
+- **Purpose:** delivers the completed dossier with PDF attachments or directs the recipient to the CRM portal link when attachments are hosted externally.
+
+Both template pairs expect the following context keys when rendered:
+
+| Key | Description | Notes |
+| --- | ----------- | ----- |
+| `recipient_name` | Friendly name for the recipient. | Typically the local-part of the email address. |
+| `company_name` | Target company covered by the dossier. | | 
+| `last_report_date` | (Existing dossier template only) ISO-formatted or human readable date of the current dossier. | |
+| `highlights` | (Final delivery template only) Bullet list or paragraph summarising key insights. | Optional; renderers may pass an empty string. |
+| `signature` | Signature block (text or HTML). | Defaults provided by `InternalResearchAgent`. |
+
+Templates fall back gracefully when optional context values are omitted thanks to safe-formatting helpers in the agent code.

--- a/tests/unit/test_email_agent.py
+++ b/tests/unit/test_email_agent.py
@@ -1,0 +1,94 @@
+"""Unit tests for the EmailAgent attachment and link handling."""
+
+from __future__ import annotations
+
+import email
+from email import policy
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from agents.email_agent import EmailAgent
+
+
+class _DummyServer:
+    def __init__(self, sent_messages: List[str]):
+        self._sent_messages = sent_messages
+
+    def __enter__(self) -> "_DummyServer":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - context cleanup
+        return None
+
+    def login(self, username: str, password: str) -> None:
+        return None
+
+    def sendmail(self, sender: str, recipient: str, message: str) -> None:
+        self._sent_messages.append(message)
+
+
+def _install_dummy_smtp(monkeypatch: pytest.MonkeyPatch, sent_messages: List[str]) -> None:
+    from agents import email_agent as email_agent_module
+
+    def _factory(*_args, **_kwargs):
+        return _DummyServer(sent_messages)
+
+    monkeypatch.setattr(email_agent_module.smtplib, "SMTP_SSL", _factory)
+
+
+def test_email_agent_attaches_pdfs_and_links(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    attachment = tmp_path / "report.pdf"
+    attachment.write_bytes(b"%PDF-1.4 test")
+
+    sent_messages: List[str] = []
+    _install_dummy_smtp(monkeypatch, sent_messages)
+
+    agent = EmailAgent("smtp.example.com", 465, "user", "pass", "sender@example.com")
+    portal_link = "https://crm.example.com/attachments/run-123/report"
+
+    result = agent.send_email(
+        "recipient@example.com",
+        "Subject",
+        "Body text",
+        html_body="<p>Body</p>",
+        attachments=[attachment],
+        attachment_links=[portal_link],
+    )
+
+    assert result is True
+    assert sent_messages, "Expected the EmailAgent to send an email"
+
+    message = email.message_from_string(sent_messages[0], policy=policy.default)
+    parts = list(message.walk())
+    attachment_parts = [
+        part for part in parts if part.get_content_type() == "application/pdf"
+    ]
+    assert attachment_parts, "Expected a PDF attachment to be included"
+
+    text_part = next(part for part in parts if part.get_content_type() == "text/plain")
+    assert "Access the dossier using the following link(s):" in text_part.get_content()
+    assert portal_link in text_part.get_content()
+
+    html_part = next(part for part in parts if part.get_content_type() == "text/html")
+    assert portal_link in html_part.get_content()
+
+
+def test_email_agent_handles_missing_attachments_gracefully(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    sent_messages: List[str] = []
+    _install_dummy_smtp(monkeypatch, sent_messages)
+
+    agent = EmailAgent("smtp.example.com", 465, "user", "pass", "sender@example.com")
+
+    result = agent.send_email(
+        "recipient@example.com",
+        "Subject",
+        "Simple body",
+    )
+
+    assert result is True
+    assert sent_messages
+    message = email.message_from_string(sent_messages[0], policy=policy.default)
+    text_part = next(part for part in message.walk() if part.get_content_type() == "text/plain")
+    assert text_part.get_content().startswith("Simple body")

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -1,0 +1,53 @@
+"""Tests for the reporting utilities that generate PDFs from JSON artefacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("reportlab")
+
+from utils.reporting import convert_research_artifacts_to_pdfs
+
+
+def test_convert_research_artifacts_to_pdfs_creates_files(tmp_path: Path) -> None:
+    dossier_data = {"company": "Acme", "summary": "Example"}
+    similar_data = {"results": ["Acme Subsidiary"]}
+
+    dossier_artifact = tmp_path / "dossier.json"
+    similar_artifact = tmp_path / "similar.json"
+    dossier_artifact.write_text(json.dumps(dossier_data))
+    similar_artifact.write_text(json.dumps(similar_data))
+
+    output_dir = tmp_path / "pdfs"
+    result = convert_research_artifacts_to_pdfs(
+        dossier_artifact,
+        similar_artifact,
+        output_dir=output_dir,
+    )
+
+    dossier_pdf = Path(result["dossier_pdf"])
+    similar_pdf = Path(result["similar_companies_pdf"])
+
+    assert dossier_pdf.exists()
+    assert similar_pdf.exists()
+    assert dossier_pdf.stat().st_size > 0
+    assert similar_pdf.stat().st_size > 0
+
+
+def test_convert_research_artifacts_accepts_mappings(tmp_path: Path) -> None:
+    result = convert_research_artifacts_to_pdfs(
+        {"company": "Example"},
+        {"results": []},
+        output_dir=tmp_path,
+    )
+
+    dossier_pdf = Path(result["dossier_pdf"])
+    similar_pdf = Path(result["similar_companies_pdf"])
+
+    assert dossier_pdf.name == "dossier_research.pdf"
+    assert similar_pdf.name == "similar_companies.pdf"
+    assert dossier_pdf.exists()
+    assert similar_pdf.exists()

--- a/utils/reporting.py
+++ b/utils/reporting.py
@@ -1,0 +1,130 @@
+"""Utilities for converting research artefacts into PDF documents."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping, MutableMapping, Optional, Sequence, Union
+
+try:  # pragma: no cover - import guard for environments without ReportLab
+    from reportlab.lib.pagesizes import LETTER
+    from reportlab.lib.units import inch
+    from reportlab.lib.utils import simpleSplit
+    from reportlab.pdfgen import canvas
+    _REPORTLAB_IMPORT_ERROR: Optional[ImportError] = None
+except ImportError as exc:  # pragma: no cover - captured for graceful error reporting
+    LETTER = (612.0, 792.0)  # type: ignore[assignment]
+    inch = 72.0  # type: ignore[assignment]
+    simpleSplit = None  # type: ignore[assignment]
+    canvas = None  # type: ignore[assignment]
+    _REPORTLAB_IMPORT_ERROR = exc
+
+from config.config import settings
+
+JsonLike = Union[str, Path, Mapping[str, Any]]
+
+
+def convert_research_artifacts_to_pdfs(
+    dossier_artifact: JsonLike,
+    similar_companies_artifact: JsonLike,
+    *,
+    output_dir: Optional[Union[str, Path]] = None,
+) -> MutableMapping[str, str]:
+    """Convert dossier and similar company JSON payloads into PDF files.
+
+    Parameters
+    ----------
+    dossier_artifact:
+        Mapping or path pointing to the dossier research JSON artefact.
+    similar_companies_artifact:
+        Mapping or path pointing to the similar companies JSON artefact.
+    output_dir:
+        Optional override for the directory where the PDF files will be written.
+
+    Returns
+    -------
+    dict
+        Mapping containing the file paths to the generated dossier and similar
+        companies PDFs. Paths are returned as POSIX strings for portability.
+    """
+
+    target_dir = Path(output_dir or settings.research_pdf_dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    dossier_payload = _load_json_payload(dossier_artifact)
+    similar_payload = _load_json_payload(similar_companies_artifact)
+
+    if _REPORTLAB_IMPORT_ERROR is not None:
+        raise ImportError(
+            "ReportLab is required to generate research PDFs. "
+            "Install the 'reportlab' package to enable reporting support."
+        ) from _REPORTLAB_IMPORT_ERROR
+
+    dossier_pdf = target_dir / _resolve_pdf_name(dossier_artifact, "dossier_research")
+    similar_pdf = target_dir / _resolve_pdf_name(
+        similar_companies_artifact, "similar_companies"
+    )
+
+    _write_json_pdf("Dossier Research", dossier_payload, dossier_pdf)
+    _write_json_pdf("Similar Companies", similar_payload, similar_pdf)
+
+    return {
+        "dossier_pdf": dossier_pdf.as_posix(),
+        "similar_companies_pdf": similar_pdf.as_posix(),
+    }
+
+
+def _load_json_payload(source: JsonLike) -> Mapping[str, Any]:
+    if isinstance(source, Mapping):
+        return source
+    path = Path(source)
+    data = path.read_text(encoding="utf-8")
+    return json.loads(data)
+
+
+def _resolve_pdf_name(source: JsonLike, fallback: str) -> str:
+    if isinstance(source, Mapping):
+        return f"{fallback}.pdf"
+    stem = Path(source).stem
+    if not stem:
+        return f"{fallback}.pdf"
+    return f"{stem}.pdf"
+
+
+def _write_json_pdf(title: str, payload: Mapping[str, Any], output_path: Path) -> None:
+    if _REPORTLAB_IMPORT_ERROR is not None:  # pragma: no cover - defensive guard
+        raise ImportError(
+            "ReportLab dependency missing; unable to generate PDF output."
+        ) from _REPORTLAB_IMPORT_ERROR
+
+    document = canvas.Canvas(str(output_path), pagesize=LETTER)
+    width, height = LETTER
+
+    header_text = document.beginText()
+    header_text.setFont("Helvetica-Bold", 14)
+    header_text.setTextOrigin(0.75 * inch, height - 0.75 * inch)
+    header_text.textLine(title)
+    header_text.setFont("Helvetica", 10)
+    header_text.textLine("")
+
+    json_lines = json.dumps(payload, indent=2, ensure_ascii=False).splitlines()
+
+    max_width = width - (1.5 * inch)
+    current_text = header_text
+
+    for line in json_lines:
+        wrapped = simpleSplit(line, "Helvetica", 10, max_width)
+        for chunk in wrapped or [""]:
+            if current_text.getY() <= 0.75 * inch:
+                document.drawText(current_text)
+                document.showPage()
+                current_text = document.beginText()
+                current_text.setTextOrigin(0.75 * inch, height - 0.75 * inch)
+                current_text.setFont("Helvetica", 10)
+            current_text.textLine(chunk)
+
+    document.drawText(current_text)
+    document.save()
+
+
+__all__: Sequence[str] = ["convert_research_artifacts_to_pdfs"]


### PR DESCRIPTION
## Summary
- extend the email agent to attach research PDFs and append CRM portal links when provided
- add a reporting utility that renders dossier and similar company JSON artefacts into PDF files using ReportLab
- introduce reusable email templates for existing dossier notices and final research delivery alongside unit tests

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dab4396de4832bbdb13213d63d4940