### PR TITLE
Add research agent schema snapshots and orchestration coverage

### DIFF
--- a/tests/unit/snapshots/company_detail_research.json
+++ b/tests/unit/snapshots/company_detail_research.json
@@ -1,0 +1,38 @@
+{
+  "report_type": "Company Detail Research",
+  "run_id": "run-123",
+  "event_id": "evt-456",
+  "generated_at": "2024-01-01T12:00:00+00:00",
+  "company": {
+    "name": "Example Corp",
+    "domain": "example.com",
+    "location": "New York, USA",
+    "industry": "Technology",
+    "description": "A sample organisation for testing purposes."
+  },
+  "summary": "Example Corp builds example solutions.",
+  "insights": [
+    "Revenue grew 25% year over year.",
+    "Expanded into two new markets in 2023."
+  ],
+  "sources": [
+    "https://example.com/press",
+    "https://news.example.com/article"
+  ],
+  "raw_input": {
+    "company_name": "Example Corp",
+    "company_domain": "example.com",
+    "company_location": "New York, USA",
+    "company_industry": "Technology",
+    "company_description": "A sample organisation for testing purposes.",
+    "summary": "Example Corp builds example solutions.",
+    "insights": [
+      "Revenue grew 25% year over year.",
+      "Expanded into two new markets in 2023."
+    ],
+    "sources": [
+      "https://example.com/press",
+      "https://news.example.com/article"
+    ]
+  }
+}

--- a/tests/unit/snapshots/similar_companies_level1.json
+++ b/tests/unit/snapshots/similar_companies_level1.json
@@ -1,0 +1,44 @@
+{
+  "company_name": "Example Analytics",
+  "run_id": "run-123",
+  "event_id": "evt-456",
+  "generated_at": "2024-01-01T12:00:00+00:00",
+  "results": [
+    {
+      "id": "1",
+      "name": "Example Analytics",
+      "domain": "example.com",
+      "score": 10.0,
+      "matching_fields": [
+        "description",
+        "name",
+        "product",
+        "segment"
+      ],
+      "properties": {
+        "name": "Example Analytics",
+        "segment": "Enterprise",
+        "product": "Insight Platform",
+        "description": "Predictive analytics tools for marketing departments.",
+        "domain": "example.com"
+      }
+    },
+    {
+      "id": "2",
+      "name": "Example Insights",
+      "domain": "insights.example",
+      "score": 3.0,
+      "matching_fields": [
+        "description",
+        "product"
+      ],
+      "properties": {
+        "name": "Example Insights",
+        "segment": "Mid-Market",
+        "product": "Insight Platform",
+        "description": "Analytics for marketing and sales teams.",
+        "domain": "insights.example"
+      }
+    }
+  ]
+}

--- a/tests/unit/test_dossier_research_agent.py
+++ b/tests/unit/test_dossier_research_agent.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -20,7 +21,8 @@ def agent(tmp_path: Path) -> DossierResearchAgent:
     return DossierResearchAgent(config=_Config(tmp_path))
 
 
-def _base_trigger() -> dict[str, object]:
+@pytest.fixture()
+def base_trigger() -> dict[str, object]:
     return {
         "run_id": "run-123",
         "event_id": "evt-456",
@@ -43,8 +45,25 @@ def _base_trigger() -> dict[str, object]:
     }
 
 
-def test_run_serializes_output_and_persists_artifact(agent: DossierResearchAgent) -> None:
-    trigger = _base_trigger()
+@pytest.fixture()
+def trigger_factory(base_trigger: dict[str, object]):
+    def _factory(**updates: object) -> dict[str, object]:
+        trigger = json.loads(json.dumps(base_trigger))
+        trigger_payload = trigger["payload"]
+        if isinstance(updates.get("payload"), dict):
+            trigger_payload.update(updates["payload"])  # type: ignore[arg-type]
+        for key, value in updates.items():
+            if key != "payload":
+                trigger[key] = value
+        return trigger
+
+    return _factory
+
+
+def test_run_serializes_output_and_persists_artifact(
+    agent: DossierResearchAgent, trigger_factory
+) -> None:
+    trigger = trigger_factory()
 
     result = agent.run(trigger)
 
@@ -65,21 +84,73 @@ def test_run_serializes_output_and_persists_artifact(agent: DossierResearchAgent
     assert list(saved_payload.keys()) == list(DossierResearchAgent.OUTPUT_FIELD_ORDER)
 
 
-def test_missing_required_fields_raise_value_error(agent: DossierResearchAgent) -> None:
-    trigger = _base_trigger()
+@pytest.mark.parametrize(
+    "insights_input,sources_input,expected_insights,expected_sources",
+    [
+        ("One liner", "https://example.com", ["One liner"], ["https://example.com"]),
+        (
+            ["Primary insight", None, 42],
+            ["https://example.com", None],
+            ["Primary insight", "42"],
+            ["https://example.com"],
+        ),
+        (None, [], [], []),
+    ],
+)
+def test_sequences_are_normalised(
+    agent: DossierResearchAgent,
+    trigger_factory,
+    insights_input,
+    sources_input,
+    expected_insights,
+    expected_sources,
+) -> None:
+    trigger = trigger_factory(payload={"insights": insights_input, "sources": sources_input})
+
+    dossier = agent.run(trigger)["payload"]
+
+    assert dossier["insights"] == expected_insights
+    assert dossier["sources"] == expected_sources
+
+
+def test_summary_falls_back_to_description(
+    agent: DossierResearchAgent, trigger_factory
+) -> None:
+    trigger = trigger_factory(
+        payload={
+            "summary": None,
+            "company_summary": "",
+            "company_description": None,
+            "description": " Provided summary ",
+        }
+    )
+
+    dossier = agent.run(trigger)["payload"]
+
+    assert dossier["summary"] == "Provided summary"
+    assert dossier["company"]["description"] == " Provided summary "
+
+
+def test_missing_required_fields_raise_value_error(
+    agent: DossierResearchAgent, trigger_factory
+) -> None:
+    trigger = trigger_factory()
     trigger["payload"].pop("company_domain")  # type: ignore[index]
 
     with pytest.raises(ValueError):
         agent.run(trigger)
 
 
-def test_artifacts_are_traceable_by_run_and_event(agent: DossierResearchAgent) -> None:
-    trigger = _base_trigger()
+def test_artifacts_are_traceable_by_run_and_event(
+    agent: DossierResearchAgent, trigger_factory
+) -> None:
+    trigger = trigger_factory()
     agent.run(trigger)
 
-    second_trigger = _base_trigger()
-    second_trigger["event_id"] = "evt-789"
-    second_trigger["payload"]["company_name"] = "Example Subsidiary"  # type: ignore[index]
+    second_trigger = trigger_factory(
+        event_id="evt-789",
+        payload={"company_name": "Example Subsidiary"},
+    )
     agent.run(second_trigger)
 
     base_dir = Path(agent.output_dir) / trigger["run_id"]
@@ -89,3 +160,29 @@ def test_artifacts_are_traceable_by_run_and_event(agent: DossierResearchAgent) -
         "evt-456_company_detail_research.json",
         "evt-789_company_detail_research.json",
     ]
+
+
+def test_company_detail_schema_snapshot(
+    agent: DossierResearchAgent, trigger_factory, monkeypatch
+) -> None:
+    class _FixedDatetime:
+        @classmethod
+        def now(cls, tz=None):
+            base = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+            if tz:
+                return base.astimezone(tz)
+            return base
+
+    monkeypatch.setattr("agents.dossier_research_agent.datetime", _FixedDatetime)
+
+    trigger = trigger_factory()
+    result = agent.run(trigger)
+
+    artifact_path = Path(result["artifact_path"])
+    saved_payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+
+    snapshot_path = Path(__file__).resolve().parent / "snapshots" / "company_detail_research.json"
+    expected_payload = json.loads(snapshot_path.read_text(encoding="utf-8"))
+
+    assert saved_payload == expected_payload
+    assert result["payload"] == expected_payload

--- a/tests/unit/test_hubspot_normalization.py
+++ b/tests/unit/test_hubspot_normalization.py
@@ -1,0 +1,69 @@
+"""Unit tests for HubSpot CRM domain normalisation helpers."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import pytest
+
+from integration.hubspot_integration import HubSpotIntegration
+
+
+@pytest.fixture()
+def hubspot_integration() -> HubSpotIntegration:
+    """Provide a HubSpot integration instance with explicit runtime config."""
+
+    return HubSpotIntegration(
+        access_token="test-token",
+        api_base_url="https://api.example.com",
+        request_timeout=5,
+        max_retries=1,
+        retry_backoff_seconds=0.0,
+    )
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("Example.COM", "example.com"),
+        ("https://www.example.com", "example.com"),
+        ("HTTP://example.com/path", "example.com"),
+        ("//www.example.org/resource", "example.org"),
+        ("   subdomain.example.io   ", "subdomain.example.io"),
+        ("", ""),
+        ("   ", ""),
+    ],
+)
+def test_normalise_domain_variants(
+    hubspot_integration: HubSpotIntegration, raw: str, expected: str
+) -> None:
+    """The helper strips schemes, prefixes, and whitespace consistently."""
+
+    assert hubspot_integration._normalise_domain(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "properties,expected",
+    [
+        ({"domain": "Example.COM", "website": "ignored"}, "example.com"),
+        ({"website": "https://sub.example.net"}, "https://sub.example.net"),
+        ({"domain": ""}, ""),
+        ({}, ""),
+    ],
+)
+def test_extract_domain_prefers_primary_field(
+    hubspot_integration: HubSpotIntegration, properties: Mapping[str, Any], expected: str
+) -> None:
+    """Domain extraction falls back across known HubSpot property names."""
+
+    company = {"properties": dict(properties)}
+    assert hubspot_integration._extract_domain(company) == expected
+
+
+def test_extract_domain_handles_non_mapping_payload(
+    hubspot_integration: HubSpotIntegration,
+) -> None:
+    """Non-mapping inputs yield an empty string rather than raising."""
+
+    assert hubspot_integration._extract_domain({"properties": None}) == ""
+    assert hubspot_integration._extract_domain({}) == ""

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Tuple
 
 import pytest
 
@@ -12,19 +13,40 @@ pytest.importorskip("reportlab")
 from utils.reporting import convert_research_artifacts_to_pdfs
 
 
-def test_convert_research_artifacts_to_pdfs_creates_files(tmp_path: Path) -> None:
+@pytest.fixture(
+    params=["path", "mapping", "mixed"],
+)
+def artifact_inputs(tmp_path: Path, request) -> Tuple[object, object, Path]:
     dossier_data = {"company": "Acme", "summary": "Example"}
-    similar_data = {"results": ["Acme Subsidiary"]}
+    similar_data = {"results": ["Acme Subsidiary"], "metadata": {"link": "https://example.com"}}
 
-    dossier_artifact = tmp_path / "dossier.json"
-    similar_artifact = tmp_path / "similar.json"
-    dossier_artifact.write_text(json.dumps(dossier_data))
-    similar_artifact.write_text(json.dumps(similar_data))
+    dossier_path = tmp_path / "dossier.json"
+    similar_path = tmp_path / "similar.json"
+    dossier_path.write_text(json.dumps(dossier_data), encoding="utf-8")
+    similar_path.write_text(json.dumps(similar_data), encoding="utf-8")
 
-    output_dir = tmp_path / "pdfs"
+    if request.param == "path":
+        dossier_source: object = dossier_path
+        similar_source: object = similar_path
+    elif request.param == "mapping":
+        dossier_source = dossier_data
+        similar_source = similar_data
+    else:
+        dossier_source = dossier_path
+        similar_source = similar_data
+
+    output_dir = tmp_path / f"pdfs_{request.param}"
+    return dossier_source, similar_source, output_dir
+
+
+def test_convert_research_artifacts_to_pdfs_creates_files(
+    artifact_inputs: Tuple[object, object, Path]
+) -> None:
+    dossier_input, similar_input, output_dir = artifact_inputs
+
     result = convert_research_artifacts_to_pdfs(
-        dossier_artifact,
-        similar_artifact,
+        dossier_input,
+        similar_input,
         output_dir=output_dir,
     )
 
@@ -35,11 +57,18 @@ def test_convert_research_artifacts_to_pdfs_creates_files(tmp_path: Path) -> Non
     assert similar_pdf.exists()
     assert dossier_pdf.stat().st_size > 0
     assert similar_pdf.stat().st_size > 0
+    assert dossier_pdf.parent == output_dir
+    assert similar_pdf.parent == output_dir
 
 
-def test_convert_research_artifacts_accepts_mappings(tmp_path: Path) -> None:
+def test_convert_research_artifacts_names_follow_inputs(tmp_path: Path) -> None:
+    dossier_artifact = tmp_path / "custom_dossier_payload.json"
+    similar_artifact = tmp_path / "candidate-list.json"
+    dossier_artifact.write_text(json.dumps({"company": "Example"}), encoding="utf-8")
+    similar_artifact.write_text(json.dumps({"results": []}), encoding="utf-8")
+
     result = convert_research_artifacts_to_pdfs(
-        {"company": "Example"},
+        dossier_artifact,
         {"results": []},
         output_dir=tmp_path,
     )
@@ -47,7 +76,5 @@ def test_convert_research_artifacts_accepts_mappings(tmp_path: Path) -> None:
     dossier_pdf = Path(result["dossier_pdf"])
     similar_pdf = Path(result["similar_companies_pdf"])
 
-    assert dossier_pdf.name == "dossier_research.pdf"
+    assert dossier_pdf.name == "custom_dossier_payload.pdf"
     assert similar_pdf.name == "similar_companies.pdf"
-    assert dossier_pdf.exists()
-    assert similar_pdf.exists()


### PR DESCRIPTION
## Summary
- add dedicated HubSpot CRM normalization unit tests exercising domain handling edge cases
- expand dossier research, similar companies, and PDF reporting unit suites with fixtures plus snapshot assertions for schema stability
- extend workflow orchestrator integration tests to confirm research artefacts persist and final email metadata is preserved

## Testing
- pytest tests/unit/test_hubspot_normalization.py tests/unit/test_dossier_research_agent.py tests/unit/test_int_lvl_1_agent.py tests/unit/test_reporting.py tests/integration/test_workflow_orchestrator_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68dac4342a88832b907597a9f11f7a98