### PR TITLE
docs: document research pipeline and artefacts

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -15,6 +15,9 @@ environments. For a visual overview of how these agents collaborate, refer to
 | [`event_polling_agent.py`](event_polling_agent.py) | Connects to Google Calendar and Google Contacts to poll upcoming events, related organiser data, and filters out noise such as birthday reminders. |
 | [`extraction_agent.py`](extraction_agent.py) | Extracts core metadata (company name, web domain) from events and flags whether the information set is complete, ready for richer parsing extensions. |
 | [`human_in_loop_agent.py`](human_in_loop_agent.py) | Facilitates human-in-the-loop interactions for gathering missing event data and confirming dossier creation via a pluggable communication backend or built-in simulator. |
+| [`internal_research_agent.py`](internal_research_agent.py) | Reuses or refreshes existing dossiers, orchestrates reminders, and prepares audit artefacts for human review. |
+| [`dossier_research_agent.py`](dossier_research_agent.py) | Generates `company_detail_research.json` artefacts containing company background, funding, and summary notes. |
+| [`int_lvl_1_agent.py`](int_lvl_1_agent.py) | Produces `similar_companies_level1.json` catalogues that highlight comparable organisations sourced from HubSpot. |
 | [`master_workflow_agent.py`](master_workflow_agent.py) | Implements the end-to-end business logic: polls events, detects triggers, performs extraction, coordinates with humans, and forwards confirmed events downstream. |
 | [`local_storage_agent.py`](local_storage_agent.py) | Persists generated artefacts such as workflow log files into a structured local directory tree for inspection. |
 | [`trigger_detection_agent.py`](trigger_detection_agent.py) | Detects hard and soft trigger phrases in event summaries and descriptions using normalised keyword matching. |
@@ -32,6 +35,7 @@ surface area that each workflow stage must expose:
 | `BaseExtractionAgent` | `extract(event)` | [`ExtractionAgent`](extraction_agent.py) |
 | `BaseHumanAgent` | `request_info(event, extracted)`, `request_dossier_confirmation(event, info)` | [`HumanInLoopAgent`](human_in_loop_agent.py) |
 | `BaseCrmAgent` | `send(event, info)` | [`LoggingCrmAgent`](crm_agent.py) |
+| `BaseResearchAgent` | `run(trigger)` | [`InternalResearchAgent`](internal_research_agent.py), [`DossierResearchAgent`](dossier_research_agent.py), [`IntLvl1SimilarCompaniesAgent`](int_lvl_1_agent.py) |
 
 Concrete implementations register themselves with the registry defined in
 [`factory.py`](factory.py) using the `@register_agent` decorator. The factory supports naming
@@ -44,6 +48,8 @@ implementations with either environment variables or a configuration file:
 
 * **Environment variables** – set `POLLING_AGENT`, `TRIGGER_AGENT`, `EXTRACTION_AGENT`,
   `HUMAN_AGENT`, or `CRM_AGENT` to the registered name of an alternative implementation.
+  Research agents are typically overridden via configuration files so that multiple
+  implementations can co-exist in different environments.
 * **Configuration file** – point `AGENT_CONFIG_FILE` to a JSON or YAML document containing an
   `agents` section. Example:
 
@@ -51,7 +57,35 @@ implementations with either environment variables or a configuration file:
 agents:
   polling: "custom_polling"
   crm_agent: "hubspot"
+  internal_research: "my_internal_research"
+  dossier_research: "my_dossier_research"
+  similar_companies: "my_similar_companies"
 ```
+
+When overriding research agents ensure that the replacement writes artefacts to the configured
+`RESEARCH_ARTIFACT_DIR` and returns payloads following the schema documented in
+[`docs/research_artifacts.md`](../docs/research_artifacts.md). The orchestrator relies on
+consistent `artifact_path`, `status`, and `agent` keys to collate results and generate PDFs.
+
+## Research pipeline responsibilities
+
+The research stage is orchestrated in three layers:
+
+1. **Internal research** – validates whether an existing dossier can be reused. If the dossier
+   is stale, the agent schedules human follow-up via the HITL channel and records the decision in
+   the audit trail.
+2. **Dossier research** – generates the core `company_detail_research.json` artefact capturing
+   company background, opportunities, and tailored talking points for organisers.
+3. **Similar companies** – ranks comparable organisations sourced from HubSpot and stores them in
+   `similar_companies_level1.json`, which downstream systems use for cross-selling insights.
+
+All research agents inherit from `BaseResearchAgent`, so they share the same logging and artifact
+contract. Each agent is expected to:
+
+- Respect the incoming `run_id` and `event_id` to keep audit records consistent.
+- Persist artefacts beneath their respective sub-directory of `RESEARCH_ARTIFACT_DIR`.
+- Return a payload with an `artifact_path` pointing to the stored file so the CRM agent can attach
+  it and the reporting utility can generate PDFs.
 
 ## Implementing a custom agent
 

--- a/docs/research_artifacts.md
+++ b/docs/research_artifacts.md
@@ -1,0 +1,132 @@
+# Research artefact reference
+
+This guide illustrates the JSON and PDF artefacts produced by the research pipeline so
+operators know exactly what to expect when reviewing deliveries or debugging runs.
+
+## Directory structure
+
+All artefacts live under the configured `RESEARCH_ARTIFACT_DIR` and `RESEARCH_PDF_DIR`.
+The orchestrator creates run-specific folders using the workflow `run_id`:
+
+```
+<RESEARCH_ARTIFACT_DIR>/
+  internal_research/<run_id>/internal_research.json
+  dossier_research/<run_id>/company_detail_research.json
+  similar_companies_level1/<run_id>/similar_companies_level1.json
+<RESEARCH_PDF_DIR>/<run_id>/
+  company_detail_research.pdf
+  similar_companies_level1.pdf
+  research_manifest.pdf
+```
+
+`research_manifest.pdf` is an optional summary generated when multiple artefacts are
+bundled together for CRM delivery. Individual PDFs mirror the JSON fields while
+adding human-readable headings and tables.
+
+## Company detail research JSON
+
+The dossier research agent produces a structured JSON report titled "Company Detail
+Research". It captures the metadata required to brief event organisers and downstream
+CRM teams.
+
+```json
+{
+  "report_type": "Company Detail Research",
+  "run_id": "run-123",
+  "event_id": "evt-456",
+  "generated_at": "2024-01-01T12:00:00+00:00",
+  "company": {
+    "name": "Example Corp",
+    "domain": "example.com",
+    "location": "New York, USA",
+    "industry": "Technology",
+    "description": "A sample organisation for testing purposes."
+  },
+  "summary": "Example Corp builds example solutions.",
+  "insights": [
+    "Revenue grew 25% year over year.",
+    "Expanded into two new markets in 2023."
+  ],
+  "sources": [
+    "https://example.com/press",
+    "https://news.example.com/article"
+  ]
+}
+```
+
+### PDF layout
+
+The generated PDF renders the same information using the following sections:
+
+1. **Executive summary** – company overview, primary industry, and key value proposition.
+2. **Signals & opportunities** – bullet list derived from the `insights` array with
+   emphasis on revenue milestones, product launches, or customer wins.
+3. **Source appendix** – clickable URLs matching the `sources` array for compliance review.
+
+Headers include the `run_id`, `event_id`, and generation timestamp so auditors can tie
+PDFs back to the originating workflow run.
+
+## Similar companies level 1 JSON
+
+The `similar_companies_level1` agent compiles peer organisations that can help with
+competitive positioning or cross-sell suggestions.
+
+```json
+{
+  "company_name": "Example Analytics",
+  "run_id": "run-123",
+  "event_id": "evt-456",
+  "generated_at": "2024-01-01T12:00:00+00:00",
+  "results": [
+    {
+      "id": "1",
+      "name": "Example Analytics",
+      "domain": "example.com",
+      "score": 10.0,
+      "matching_fields": ["description", "name", "product", "segment"],
+      "properties": {
+        "name": "Example Analytics",
+        "segment": "Enterprise",
+        "product": "Insight Platform",
+        "description": "Predictive analytics tools for marketing departments.",
+        "domain": "example.com"
+      }
+    }
+  ]
+}
+```
+
+### PDF layout
+
+The PDF output summarises the `results` array as a ranked table with columns for name,
+domain, segment, product, and a bar showing the similarity `score`. A final appendix
+captures the detailed `properties` dictionary for each match so operators can copy the
+information into CRM records quickly.
+
+## Internal research manifest
+
+When the internal research agent reuses an existing dossier it records the decision in
+`internal_research.json` and mirrors the metadata into the run summary. Typical fields
+include:
+
+- `status` – `reuse`, `refresh_requested`, or `not_found`.
+- `source_artifact` – the absolute path to the prior dossier that was reused.
+- `owner` – the last researcher to update the dossier.
+- `expires_at` – ISO timestamp indicating when a refresh should be triggered.
+
+If a refresh is required the manifest also lists `reminder_schedule` entries that feed
+into the HITL escalation loop.
+
+## CRM delivery expectations
+
+Final deliveries provide both JSON and PDF artefacts:
+
+- Emails generated from `templates/email/final_research_delivery.*` attach the PDFs and
+  link to the JSON artefacts using `CRM_ATTACHMENT_BASE_URL` when configured.
+- CRM notes reference the same portal links so organisers and sales teams can download
+  the dossier bundle without leaving their workflow.
+- The run summary stored under `log_storage/run_history/research/workflow_runs/<run_id>/`
+  lists every artefact path and delivery status for auditing.
+
+Use these samples to verify that new integrations or custom agents continue to emit
+artefacts in the expected format.


### PR DESCRIPTION
## Summary
- expand the main README, architecture overview, and agents guide with detailed research workflow, HITL, and delivery documentation
- describe configuration options for the research agents and CRM integrations, including PDF handling and reuse logic
- add a dedicated research artefact reference with example JSON structures and PDF expectations for operators

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dac8a1f1d0832b90c1d3934218e804