### PR TITLE
Fix handling of hard triggers with complete info

### DIFF
--- a/agents/master_workflow_agent.py
+++ b/agents/master_workflow_agent.py
@@ -262,6 +262,7 @@ class MasterWorkflowAgent:
                         event_id,
                         force_internal=False,
                     )
+                    continue
                 else:
                     with observe_operation(
                         "hitl_missing_info",

--- a/tests/test_master_workflow_agent_hard_trigger.py
+++ b/tests/test_master_workflow_agent_hard_trigger.py
@@ -1,0 +1,65 @@
+from typing import Any, Dict, Iterable
+
+from agents.master_workflow_agent import MasterWorkflowAgent
+
+
+class DummyEventAgent:
+    def __init__(self, events: Iterable[Dict[str, Any]]):
+        self._events = list(events)
+
+    def poll(self) -> Iterable[Dict[str, Any]]:
+        return list(self._events)
+
+
+class DummyTriggerAgent:
+    def __init__(self, result: Dict[str, Any]):
+        self._result = result
+
+    def check(self, _event: Dict[str, Any]) -> Dict[str, Any]:
+        return dict(self._result)
+
+
+class DummyExtractionAgent:
+    def __init__(self, response: Dict[str, Any]):
+        self._response = response
+
+    def extract(self, _event: Dict[str, Any]) -> Dict[str, Any]:
+        return dict(self._response)
+
+
+def test_hard_trigger_with_complete_info_dispatches_without_unhandled_state() -> None:
+    event = {"id": "event-001", "summary": "Hard trigger meeting"}
+    info = {"company_name": "Example Corp", "company_domain": "example.com"}
+
+    agent = MasterWorkflowAgent(
+        event_agent=DummyEventAgent([event]),
+        trigger_agent=DummyTriggerAgent({"trigger": True, "type": "hard"}),
+        extraction_agent=DummyExtractionAgent({"info": info, "is_complete": True}),
+    )
+
+    dispatched: Dict[str, Any] = {"called": False}
+
+    def _fake_process_crm_dispatch(
+        _event: Dict[str, Any],
+        _info: Dict[str, Any],
+        event_result: Dict[str, Any],
+        _event_id: Any,
+        *,
+        force_internal: bool,
+    ) -> None:
+        dispatched["called"] = True
+        dispatched["force_internal"] = force_internal
+        event_result["status"] = "dispatched_to_crm"
+        event_result["crm_payload"] = {"info": _info}
+
+    agent._process_crm_dispatch = _fake_process_crm_dispatch  # type: ignore[assignment]
+
+    try:
+        results = agent.process_all_events()
+    finally:
+        agent.finalize_run_logs()
+
+    assert dispatched["called"] is True
+    assert dispatched["force_internal"] is False
+    assert results[0]["status"] == "dispatched_to_crm"
+    assert results[0]["crm_payload"] == {"info": info}


### PR DESCRIPTION
## Summary
- ensure the hard trigger path exits immediately after dispatching to the CRM
- add regression coverage for hard triggers with complete information to prevent future regressions

## Testing
- pytest tests/test_master_workflow_agent_hard_trigger.py

------
https://chatgpt.com/codex/tasks/task_e_68dad0d39ca8832b872968a1ec1bf6ba