### PR TITLE
Update trigger detection to use substring matching

### DIFF
--- a/agents/trigger_detection_agent.py
+++ b/agents/trigger_detection_agent.py
@@ -1,5 +1,4 @@
-import re
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 from agents.factory import register_agent
 from agents.interfaces import BaseTriggerAgent
@@ -16,10 +15,6 @@ class TriggerDetectionAgent(BaseTriggerAgent):
         else:
             # Default trigger words, falls keine übergeben wurden
             self.trigger_words = (normalize_text("trigger word"),)
-
-        self._patterns: Tuple[re.Pattern[str], ...] = tuple(
-            re.compile(re.escape(word)) for word in self.trigger_words
-        )
 
     def check(self, event: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -47,8 +42,8 @@ class TriggerDetectionAgent(BaseTriggerAgent):
 
         normalized_text = normalize_text(text)
 
-        for word, pattern in zip(self.trigger_words, self._patterns):
-            if pattern.search(normalized_text):
+        for word in self.trigger_words:
+            if word in normalized_text:
                 trigger_type = "hard" if field_name == "summary" else "soft"
                 return {
                     "trigger": True,

--- a/tests/test_trigger_detection_agent.py
+++ b/tests/test_trigger_detection_agent.py
@@ -27,6 +27,18 @@ def test_agent_detects_description_soft_trigger() -> None:
     }
 
 
+def test_agent_detects_trigger_within_longer_text() -> None:
+    agent = TriggerDetectionAgent(trigger_words=["business client"])
+
+    result = agent.check({"summary": "business client condata - v2"})
+    assert result == {
+        "trigger": True,
+        "type": "hard",
+        "matched_word": normalize_text("business client"),
+        "matched_field": "summary",
+    }
+
+
 def test_agent_falls_back_to_defaults_when_no_triggers() -> None:
     agent = TriggerDetectionAgent(trigger_words=[])
     assert agent.trigger_words


### PR DESCRIPTION
## Summary
- update `TriggerDetectionAgent` to look for trigger words as substrings in normalized text
- add a regression test to ensure triggers embedded in longer text are detected

## Testing
- pytest tests/test_trigger_detection_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68dae9a5e8d0832b8ccdd50230082bda