### PR TITLE
Format report timestamps in CET style

### DIFF
--- a/agents/dossier_research_agent.py
+++ b/agents/dossier_research_agent.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 from agents.factory import register_agent
 from agents.interfaces import BaseResearchAgent
 from config.config import settings
+from utils.datetime_formatting import format_report_datetime
 
 
 class DossierResearchAgent(BaseResearchAgent):
@@ -122,7 +123,7 @@ class DossierResearchAgent(BaseResearchAgent):
     def _build_dossier_payload(
         self, payload: Mapping[str, Any], run_id: str, event_id: str
     ) -> OrderedDict[str, Any]:
-        generated_at = datetime.now(timezone.utc).isoformat()
+        generated_at = format_report_datetime(datetime.now(timezone.utc))
 
         company_section = OrderedDict()
         company_values = {

--- a/agents/int_lvl_1_agent.py
+++ b/agents/int_lvl_1_agent.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional,
 from agents.factory import register_agent
 from agents.interfaces import BaseResearchAgent
 from config.config import settings
+from utils.datetime_formatting import format_report_datetime
 from integration.hubspot_integration import HubSpotIntegration
 from utils.text_normalization import normalize_text
 
@@ -120,7 +121,7 @@ class IntLvl1SimilarCompaniesAgent(BaseResearchAgent):
             "company_name": target_context["company_name"],
             "run_id": run_id or None,
             "event_id": event_id or None,
-            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "generated_at": format_report_datetime(datetime.now(timezone.utc)),
             "results": limited_results,
         }
 

--- a/agents/internal_research_agent.py
+++ b/agents/internal_research_agent.py
@@ -17,6 +17,7 @@ from agents.email_agent import EmailAgent
 from config.config import settings
 from logs.workflow_log_manager import WorkflowLogManager
 from reminders.reminder_escalation import ReminderEscalation
+from utils.datetime_formatting import format_report_datetime
 
 NormalizedPayload = Dict[str, Any]
 
@@ -495,13 +496,7 @@ class InternalResearchAgent(BaseResearchAgent):
             return None
 
         company_name = payload.get("company_name") or "the requested company"
-        try:
-            parsed_last = datetime.fromisoformat(
-                str(last_report_date).replace("Z", "+00:00")
-            )
-            display_date = parsed_last.strftime("%Y-%m-%d")
-        except Exception:  # pragma: no cover - defensive formatting
-            display_date = str(last_report_date)
+        display_date = format_report_datetime(last_report_date)
 
         subject = f"Existing research available for {company_name}"
         first_name = recipient.split("@", 1)[0]

--- a/agents/local_storage_agent.py
+++ b/agents/local_storage_agent.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, Optional
+
+from utils.datetime_formatting import current_berlin_timestamp
 
 
 Metadata = Dict[str, object]
@@ -78,7 +79,7 @@ class LocalStorageAgent:
         entry: Metadata = {
             "run_id": run_id,
             "log_path": log_reference,
-            "recorded_at": datetime.now(timezone.utc).isoformat(),
+            "recorded_at": current_berlin_timestamp(),
         }
         if metadata:
             entry.update(metadata)

--- a/docs/research_artifacts.md
+++ b/docs/research_artifacts.md
@@ -34,7 +34,7 @@ CRM teams.
   "report_type": "Company Detail Research",
   "run_id": "run-123",
   "event_id": "evt-456",
-  "generated_at": "2024-01-01T12:00:00+00:00",
+  "generated_at": "01.01.2024 13:00",
   "company": {
     "name": "Example Corp",
     "domain": "example.com",
@@ -76,7 +76,7 @@ competitive positioning or cross-sell suggestions.
   "company_name": "Example Analytics",
   "run_id": "run-123",
   "event_id": "evt-456",
-  "generated_at": "2024-01-01T12:00:00+00:00",
+  "generated_at": "01.01.2024 13:00",
   "results": [
     {
       "id": "1",
@@ -112,7 +112,8 @@ include:
 - `status` – `reuse`, `refresh_requested`, or `not_found`.
 - `source_artifact` – the absolute path to the prior dossier that was reused.
 - `owner` – the last researcher to update the dossier.
-- `expires_at` – ISO timestamp indicating when a refresh should be triggered.
+- `expires_at` – timestamp formatted as `TT.MM.JJJJ HH:MM` (Europe/Berlin) indicating when a
+  refresh should be triggered.
 
 If a refresh is required the manifest also lists `reminder_schedule` entries that feed
 into the HITL escalation loop.

--- a/logs/event_log_manager.py
+++ b/logs/event_log_manager.py
@@ -1,9 +1,10 @@
 import json
 import logging
 import re
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
+
+from utils.datetime_formatting import current_berlin_timestamp
 
 
 _SAFE_NAME = re.compile(r"[^A-Za-z0-9_.-]+")
@@ -35,7 +36,7 @@ class EventLogManager:
         """Persist the event payload to disk."""
 
         payload = dict(data)
-        payload["last_updated"] = datetime.now(timezone.utc).isoformat()
+        payload["last_updated"] = current_berlin_timestamp()
 
         event_file = self._event_file(event_id)
         with event_file.open("w", encoding="utf-8") as handle:

--- a/logs/workflow_log_manager.py
+++ b/logs/workflow_log_manager.py
@@ -1,9 +1,10 @@
 import json
 import logging
 import re
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, Optional
+
+from utils.datetime_formatting import current_berlin_timestamp
 
 _SAFE_NAME = re.compile(r"[^A-Za-z0-9_.-]+")
 
@@ -41,7 +42,7 @@ class WorkflowLogManager:
         """Append a log entry to the workflow log."""
 
         entry: Dict[str, Optional[str]] = {
-            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "timestamp": current_berlin_timestamp(),
             "run_id": run_id,
             "step": step,
             "message": message,

--- a/reminders/reminder_escalation.py
+++ b/reminders/reminder_escalation.py
@@ -3,6 +3,8 @@ import threading
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Dict, List, Optional
 
+from utils.datetime_formatting import format_report_datetime
+
 
 class ReminderEscalation:
     """Module for sending reminders and escalation notifications."""
@@ -145,7 +147,7 @@ class ReminderEscalation:
         due_time = datetime.now(timezone.utc) + timedelta(seconds=max(delay_seconds, 0))
         self._append_log(
             f"{action}_scheduled",
-            f"{action.capitalize()} scheduled for {recipient} at {due_time.isoformat()} ({subject})",
+            f"{action.capitalize()} scheduled for {recipient} at {format_report_datetime(due_time)} ({subject})",
             metadata=metadata,
         )
 

--- a/templates/email_templates.md
+++ b/templates/email_templates.md
@@ -18,7 +18,7 @@ Both template pairs expect the following context keys when rendered:
 | --- | ----------- | ----- |
 | `recipient_name` | Friendly name for the recipient. | Typically the local-part of the email address. |
 | `company_name` | Target company covered by the dossier. | | 
-| `last_report_date` | (Existing dossier template only) ISO-formatted or human readable date of the current dossier. | |
+| `last_report_date` | (Existing dossier template only) Date/time formatted as `TT.MM.JJJJ HH:MM` in Europe/Berlin. | |
 | `highlights` | (Final delivery template only) Bullet list or paragraph summarising key insights. | Optional; renderers may pass an empty string. |
 | `signature` | Signature block (text or HTML). | Defaults provided by `InternalResearchAgent`. |
 

--- a/tests/unit/snapshots/company_detail_research.json
+++ b/tests/unit/snapshots/company_detail_research.json
@@ -2,7 +2,7 @@
   "report_type": "Company Detail Research",
   "run_id": "run-123",
   "event_id": "evt-456",
-  "generated_at": "2024-01-01T12:00:00+00:00",
+  "generated_at": "01.01.2024 13:00",
   "company": {
     "name": "Example Corp",
     "domain": "example.com",

--- a/tests/unit/snapshots/similar_companies_level1.json
+++ b/tests/unit/snapshots/similar_companies_level1.json
@@ -2,7 +2,7 @@
   "company_name": "Example Analytics",
   "run_id": "run-123",
   "event_id": "evt-456",
-  "generated_at": "2024-01-01T12:00:00+00:00",
+  "generated_at": "01.01.2024 13:00",
   "results": [
     {
       "id": "1",

--- a/utils/audit_log.py
+++ b/utils/audit_log.py
@@ -7,9 +7,10 @@ import logging
 import threading
 import uuid
 from dataclasses import asdict, dataclass
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
+
+from utils.datetime_formatting import current_berlin_timestamp
 
 
 @dataclass
@@ -86,7 +87,7 @@ class AuditLog:
         entry_id = audit_id or uuid.uuid4().hex
         record = AuditRecord(
             audit_id=entry_id,
-            timestamp=datetime.now(timezone.utc).isoformat(),
+            timestamp=current_berlin_timestamp(),
             event_id=event_id,
             request_type=request_type,
             stage=stage,

--- a/utils/datetime_formatting.py
+++ b/utils/datetime_formatting.py
@@ -1,0 +1,70 @@
+"""Helpers for consistent Europe/Berlin date and time formatting."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Union
+
+try:  # pragma: no cover - zoneinfo is available from Python 3.9+
+    from zoneinfo import ZoneInfo
+except ImportError:  # pragma: no cover - fallback for alternative runtimes
+    ZoneInfo = None  # type: ignore[assignment]
+
+if ZoneInfo is not None:  # pragma: no branch
+    _BERLIN = ZoneInfo("Europe/Berlin")
+else:  # pragma: no cover - exercised only when zoneinfo is unavailable
+    _BERLIN = timezone(timedelta(hours=1))
+
+_LOG_DATETIME_FORMAT = "%Y-%m-%d %H:%M"
+_REPORT_DATETIME_FORMAT = "%d.%m.%Y %H:%M"
+
+
+def _ensure_datetime(value: Union[str, datetime]) -> Union[datetime, None]:
+    """Normalise *value* to an aware :class:`~datetime.datetime` when possible."""
+
+    if isinstance(value, datetime):
+        candidate = value
+    else:
+        try:
+            candidate = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        except Exception:  # pragma: no cover - defensive fallback for custom inputs
+            return None
+
+    if candidate.tzinfo is None:
+        candidate = candidate.replace(tzinfo=timezone.utc)
+
+    return candidate
+
+
+def current_berlin_timestamp() -> str:
+    """Return the current time formatted for the Europe/Berlin timezone."""
+
+    berlin_timestamp = datetime.now(tz=_BERLIN)
+    return berlin_timestamp.strftime(_LOG_DATETIME_FORMAT)
+
+
+def format_report_datetime(value: Union[str, datetime]) -> str:
+    """Format *value* using the Europe/Berlin specification.
+
+    Parameters
+    ----------
+    value:
+        A datetime object or ISO-8601 like string representing the timestamp.
+
+    Returns
+    -------
+    str
+        Timestamp formatted as ``TT.MM.JJJJ HH:MM`` (e.g. ``30.09.2025 08:25``).
+        Unparseable inputs are returned unchanged so calling code can decide
+        how to handle them.
+    """
+
+    candidate = _ensure_datetime(value)
+    if candidate is None:
+        return str(value)
+
+    berlin_timestamp = candidate.astimezone(_BERLIN)
+    return berlin_timestamp.strftime(_REPORT_DATETIME_FORMAT)
+
+
+__all__ = ["current_berlin_timestamp", "format_report_datetime"]


### PR DESCRIPTION
## Summary
- adjust the datetime helper to keep log timestamps in YYYY-MM-DD HH:MM while emitting report timestamps as TT.MM.JJJJ HH:MM in the Europe/Berlin timezone
- refresh research artefact documentation, email template guidance, and JSON snapshots to illustrate the CET-formatted timestamps

## Testing
- pytest tests/unit/test_dossier_research_agent.py tests/unit/test_int_lvl_1_agent.py
- pytest tests/unit/test_audit_log.py

------
https://chatgpt.com/codex/tasks/task_e_68db947da0cc832bb3de884628e5c2e8