### PR TITLE
Restrict polling workflow to manual dispatch with secrets

### DIFF
--- a/.github/workflows/polling_trigger.yml
+++ b/.github/workflows/polling_trigger.yml
@@ -2,27 +2,40 @@ name: Run Agentic Intelligence Research Workflow
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-      - master
 
 jobs:
   run-main-workflow:
     runs-on: ubuntu-latest
+    env:
+      SETTINGS_SKIP_DOTENV: "1"
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      OPENAI_API_BASE: ${{ secrets.OPENAI_API_BASE }}
+      GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+      GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+      GOOGLE_REFRESH_TOKEN: ${{ secrets.GOOGLE_REFRESH_TOKEN }}
+      GOOGLE_TOKEN_URI: ${{ secrets.GOOGLE_TOKEN_URI }}
+      GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
+      HUBSPOT_ACCESS_TOKEN: ${{ secrets.HUBSPOT_ACCESS_TOKEN }}
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-
+      - name: Verify required secrets
+        run: |
+          python - <<'PY'
+          import os, sys
+          required = ["OPENAI_API_KEY","GOOGLE_CLIENT_ID","GOOGLE_CLIENT_SECRET",
+                      "GOOGLE_REFRESH_TOKEN","GOOGLE_CALENDAR_ID"]
+          missing = [k for k in required if not os.getenv(k)]
+          if missing:
+              print("Missing required secrets:", ", ".join(missing))
+              sys.exit(1)
+          PY
       - name: Run main.py entrypoint
         run: python main.py


### PR DESCRIPTION
## Summary
- limit the polling workflow to manual dispatch only
- inject required environment secrets and skip dotenv usage during runs
- fail early when required secrets are missing before executing the main entrypoint

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc4aeb2588832b906312debde68bfe