### PR TITLE
Add packaging metadata and CLI entry point

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,13 +8,13 @@ Entrypoint for the Agentic Intelligence Research workflow.
 
 from dotenv import load_dotenv
 
-load_dotenv()
 
-import logging
-from agents.workflow_orchestrator import WorkflowOrchestrator
+def main() -> None:
+    load_dotenv()
 
-if __name__ == "__main__":
-    # Set up logging (optional: customize as needed)
+    import logging
+    from agents.workflow_orchestrator import WorkflowOrchestrator
+
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s %(levelname)s [run_id=%(run_id)s] %(message)s",
@@ -22,3 +22,7 @@ if __name__ == "__main__":
 
     orchestrator = WorkflowOrchestrator()
     orchestrator.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "lead-market-insights"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+  "python-dotenv>=1,<2", "watchdog>=3,<4",
+  "google-api-python-client>=2,<3","google-auth>=2.33,<3","google-auth-oauthlib>=1,<2",
+  "email-validator>=2,<3",
+  "requests>=2.31,<3","httpx>=0.27,<1",
+  "aiosmtplib>=2,<3","tenacity>=9,<10",
+  "opentelemetry-api>=1.24,<2","opentelemetry-sdk>=1.24,<2","opentelemetry-exporter-otlp>=1.24,<2",
+  "reportlab>=3.6,<4",
+  "schedule>=1.2,<2","APScheduler>=3.10,<4"
+]
+
+[project.scripts]
+leadmi = "main:main"
+
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- add a pyproject.toml so the project can be installed as a package with its dependencies
- expose a leadmi console script entry point that runs the workflow orchestrator
- refactor main.py to provide a reusable main() entry function

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc4c226454832b9cbcbf8cc228347e