### PR TITLE
Enforce required Google Calendar ID configuration

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -227,7 +227,10 @@ class Settings:
         self.cal_lookahead_days: int = _get_int_env("CAL_LOOKAHEAD_DAYS", 14)
         self.cal_lookback_days: int = _get_int_env("CAL_LOOKBACK_DAYS", 1)
 
-        self.google_calendar_id: str = _get_env_var("GOOGLE_CALENDAR_ID") or "info@condata.io"
+        value = _get_env_var("GOOGLE_CALENDAR_ID")
+        if not value:
+            raise EnvironmentError("GOOGLE_CALENDAR_ID must be set")
+        self.google_calendar_id: str = value
         self.google_oauth_credentials: Dict[str, str] = (
             self._load_google_oauth_credentials()
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from collections import defaultdict
 from pathlib import Path
@@ -19,22 +20,8 @@ if STUBS.exists() and str(STUBS) not in sys.path:
     sys.path.insert(0, str(STUBS))
 
 
-@pytest.fixture(autouse=True, scope="session")
-def _ensure_google_calendar_id() -> None:
-    """Guarantee a deterministic calendar identifier during tests.
-
-    The production configuration now requires ``GOOGLE_CALENDAR_ID`` to be
-    provided explicitly. Unit tests do not rely on a real calendar, so we
-    inject a stable placeholder to keep imports lightweight while still
-    exercising the stricter configuration behaviour in integration tests.
-    """
-
-    monkeypatch = pytest.MonkeyPatch()
-    monkeypatch.setenv("GOOGLE_CALENDAR_ID", "test-calendar@example.com")
-    try:
-        yield
-    finally:
-        monkeypatch.undo()
+DEFAULT_TEST_GOOGLE_CALENDAR_ID = "test-calendar@example.com"
+os.environ.setdefault("GOOGLE_CALENDAR_ID", DEFAULT_TEST_GOOGLE_CALENDAR_ID)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,24 @@ if STUBS.exists() and str(STUBS) not in sys.path:
     sys.path.insert(0, str(STUBS))
 
 
+@pytest.fixture(autouse=True, scope="session")
+def _ensure_google_calendar_id() -> None:
+    """Guarantee a deterministic calendar identifier during tests.
+
+    The production configuration now requires ``GOOGLE_CALENDAR_ID`` to be
+    provided explicitly. Unit tests do not rely on a real calendar, so we
+    inject a stable placeholder to keep imports lightweight while still
+    exercising the stricter configuration behaviour in integration tests.
+    """
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setenv("GOOGLE_CALENDAR_ID", "test-calendar@example.com")
+    try:
+        yield
+    finally:
+        monkeypatch.undo()
+
+
 @pytest.fixture
 def isolated_agent_registry(monkeypatch):
     """Provide an isolated registry for agent factory tests.

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -3,11 +3,21 @@
 import importlib
 from pathlib import Path
 
+import pytest
+
 
 def reload_settings():
     config_module = importlib.import_module("config.config")
     importlib.reload(config_module)
     return config_module.settings
+
+
+def test_google_calendar_id_required(monkeypatch):
+    monkeypatch.setenv("SETTINGS_SKIP_DOTENV", "1")
+    monkeypatch.delenv("GOOGLE_CALENDAR_ID", raising=False)
+
+    with pytest.raises(EnvironmentError):
+        reload_settings()
 
 
 def test_log_storage_dir_defaults(monkeypatch):


### PR DESCRIPTION
## Summary
- require the GOOGLE_CALENDAR_ID environment variable to be set instead of using a default value
- raise an explicit error when the variable is missing to avoid accidental access to the wrong calendar

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc4d13b56c832ba3683965ecffab15