### PR TITLE
Add Docker ignore file to omit archives and documentation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+ARCHIVE/
+tests/
+docs/
+.github/
+.gitignore


### PR DESCRIPTION
## Summary
- add a `.dockerignore` to keep archives, tests, docs, and Git metadata out of Docker build contexts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc5045e1d4832b8de522f8a605d78d