### PR TITLE
Add release note about ZIP snapshots lacking git history

### DIFF
--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -51,6 +51,9 @@ stricter privacy requirements.
   legal review ticket in the pull request description.
 * When introducing new agents, update [`docs/architecture.md`](architecture.md) to explain the
   data flow and specify the controls applied at each stage.
+* During the release process, add the note "ZIP-Snapshot ohne .git/ – Herkunft/Historie extern
+  prüfen." whenever publishing artefacts created from a repository snapshot to make missing Git
+  history explicit for audit reviewers.
 
 ## Incident response
 


### PR DESCRIPTION
## Summary
- document that release checklists must include a note clarifying when a ZIP snapshot lacks the `.git/` history so auditors verify provenance externally

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc50d52788832b93b3edb7700e7f13