### PR TITLE
Make Google Calendar API base URL configurable

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -234,6 +234,9 @@ class Settings:
         self.google_oauth_credentials: Dict[str, str] = (
             self._load_google_oauth_credentials()
         )
+        self.google_api_base_url: str = (
+            _get_env_var("GOOGLE_API_BASE_URL") or "https://www.googleapis.com"
+        )
 
         project_root = Path(__file__).resolve().parents[1]
         default_log_root = project_root / "log_storage" / "run_history"

--- a/integration/google_calendar_integration.py
+++ b/integration/google_calendar_integration.py
@@ -30,6 +30,7 @@ class GoogleCalendarIntegration:
     """High-level Google Calendar integration with async HTTP support."""
 
     DEFAULT_SCOPE: str = "https://www.googleapis.com/auth/calendar.readonly"
+
     def __init__(
         self,
         credentials: Optional[Dict[str, str]] = None,

--- a/integration/google_calendar_integration.py
+++ b/integration/google_calendar_integration.py
@@ -30,8 +30,6 @@ class GoogleCalendarIntegration:
     """High-level Google Calendar integration with async HTTP support."""
 
     DEFAULT_SCOPE: str = "https://www.googleapis.com/auth/calendar.readonly"
-    GOOGLE_CALENDAR_API_URL: str = "https://www.googleapis.com"
-
     def __init__(
         self,
         credentials: Optional[Dict[str, str]] = None,
@@ -54,7 +52,7 @@ class GoogleCalendarIntegration:
         self.cal_lookback_days = self._settings.cal_lookback_days
 
         self._calendar_http = AsyncHTTP(
-            base_url=self.GOOGLE_CALENDAR_API_URL,
+            base_url=self._settings.google_api_base_url,
             timeout=float(self.request_timeout),
         )
         self._token_http = AsyncHTTP(timeout=float(self.request_timeout))


### PR DESCRIPTION
## Summary
- add a configurable Google API base URL to the application settings
- use the settings-provided base URL when constructing the Google Calendar HTTP client

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc54421b30832b980f4fcce40c1f9b