### PR TITLE
Refactor agents to async interfaces

### DIFF
--- a/agents/crm_agent.py
+++ b/agents/crm_agent.py
@@ -15,6 +15,6 @@ logger = logging.getLogger(__name__)
 class LoggingCrmAgent(BaseCrmAgent):
     """Default CRM agent that logs outgoing payloads locally."""
 
-    def send(self, event: Mapping[str, Any], info: Mapping[str, Any]) -> None:
+    async def send(self, event: Mapping[str, Any], info: Mapping[str, Any]) -> None:
         event_id = event.get("id") if isinstance(event, Mapping) else None
         logger.info("Sending event %s to CRM with info: %s", event_id, dict(info))

--- a/agents/dossier_research_agent.py
+++ b/agents/dossier_research_agent.py
@@ -60,7 +60,7 @@ class DossierResearchAgent(BaseResearchAgent):
     # ------------------------------------------------------------------
     # BaseResearchAgent API
     # ------------------------------------------------------------------
-    def run(self, trigger: Mapping[str, Any]) -> MutableMapping[str, Any]:  # type: ignore[override]
+    async def run(self, trigger: Mapping[str, Any]) -> MutableMapping[str, Any]:  # type: ignore[override]
         payload = self._extract_payload(trigger)
         self._validate_payload(payload)
 

--- a/agents/int_lvl_1_agent.py
+++ b/agents/int_lvl_1_agent.py
@@ -95,7 +95,7 @@ class IntLvl1SimilarCompaniesAgent(BaseResearchAgent):
     # ------------------------------------------------------------------
     # BaseResearchAgent API
     # ------------------------------------------------------------------
-    def run(self, trigger: Mapping[str, Any]) -> MutableMapping[str, Any]:  # type: ignore[override]
+    async def run(self, trigger: Mapping[str, Any]) -> MutableMapping[str, Any]:  # type: ignore[override]
         payload = self._extract_payload(trigger)
         company_name = self._normalise_company_name(payload)
         if not company_name:

--- a/agents/interfaces/base.py
+++ b/agents/interfaces/base.py
@@ -38,6 +38,9 @@ class BaseHumanAgent(ABC):
     """Contract for human-in-the-loop escalation and confirmation flows."""
 
     @abstractmethod
+    # NOTE: Diese Methoden bleiben vorerst synchron, da aktuelle Implementierungen
+    #       keine asynchronen Nebenwirkungen besitzen. Netzwerk-Hooks werden bei
+    #       Bedarf in einem späteren Schritt auf async angehoben.
     def request_info(self, event: Mapping[str, Any], extracted: Dict[str, Any]) -> Dict[str, Any]:
         """Request missing information from a human collaborator."""
 
@@ -50,7 +53,7 @@ class BaseCrmAgent(ABC):
     """Contract for agents that persist qualified events into a CRM system."""
 
     @abstractmethod
-    def send(self, event: Mapping[str, Any], info: Mapping[str, Any]) -> None:
+    async def send(self, event: Mapping[str, Any], info: Mapping[str, Any]) -> None:
         """Persist the event with the extracted information into the CRM system."""
 
 
@@ -58,5 +61,5 @@ class BaseResearchAgent(ABC):
     """Contract for agents that perform internal research workflows."""
 
     @abstractmethod
-    def run(self, trigger: Mapping[str, Any]) -> Mapping[str, Any]:
+    async def run(self, trigger: Mapping[str, Any]) -> Mapping[str, Any]:
         """Execute a research workflow and return a normalized payload."""

--- a/agents/internal_research_agent.py
+++ b/agents/internal_research_agent.py
@@ -86,7 +86,7 @@ class InternalResearchAgent(BaseResearchAgent):
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
-    def run(self, trigger: Mapping[str, Any]) -> NormalizedPayload:  # type: ignore[override]
+    async def run(self, trigger: Mapping[str, Any]) -> NormalizedPayload:  # type: ignore[override]
         payload = self._clone_payload(trigger.get("payload"))
         context = str(trigger.get("source") or "")
         self._normalise_payload(payload)

--- a/agents/master_workflow_agent.py
+++ b/agents/master_workflow_agent.py
@@ -1,5 +1,6 @@
 """MasterWorkflowAgent: Pure logic agent for polling and event-processing."""
 
+import asyncio
 import json
 import logging
 from datetime import datetime, timezone
@@ -423,7 +424,8 @@ class MasterWorkflowAgent:
         return self.trigger_agent.check(event)
 
     def _send_to_crm_agent(self, event: Dict[str, Any], info: Dict[str, Any]) -> None:
-        self.crm_agent.send(event, info)
+        # TODO: Wird in PR3 auf await umgestellt.
+        asyncio.run(self.crm_agent.send(event, info))
 
     def _create_research_agent(
         self,
@@ -534,7 +536,8 @@ class MasterWorkflowAgent:
         attributes = {"event.id": str(event_id)} if event_id is not None else None
         with observe_operation(agent_name, attributes):
             try:
-                result = agent.run(trigger)
+                # TODO: Wird in PR3 auf await umgestellt.
+                result = asyncio.run(agent.run(trigger))
             except Exception as exc:  # pragma: no cover - defensive guard
                 logger.exception(
                     "%s research agent failed for event %s", agent_name, event_id

--- a/agents/workflow_orchestrator.py
+++ b/agents/workflow_orchestrator.py
@@ -73,6 +73,7 @@ class WorkflowOrchestrator:
                 if self.master_agent:
                     if hasattr(self.master_agent, "initialize_run"):
                         self.master_agent.initialize_run(run_context.run_id)
+                    # TODO: Wird in PR3 auf await umgestellt.
                     results = self.master_agent.process_all_events() or []
                     self._report_research_errors(run_context.run_id, results)
                     try:

--- a/tests/unit/test_int_lvl_1_agent.py
+++ b/tests/unit/test_int_lvl_1_agent.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from datetime import datetime, timezone
 from pathlib import Path
@@ -127,7 +128,7 @@ def test_ranked_results_are_limited_and_persisted(
 ) -> None:
     trigger = trigger_factory()
 
-    result = tmp_agent.run(trigger)
+    result = asyncio.run(tmp_agent.run(trigger))
 
     payload = result["payload"]
     assert payload["company_name"] == "Example Analytics"
@@ -169,7 +170,7 @@ def test_deterministic_ordering_when_scores_equal(tmp_path: Path) -> None:
         }
     }
 
-    results = agent.run(trigger)["payload"]["results"]
+    results = asyncio.run(agent.run(trigger))["payload"]["results"]
     assert [item["name"] for item in results] == ["Alpha Labs", "Beta Systems"]
 
 
@@ -181,7 +182,7 @@ def test_missing_company_name_raises_value_error(tmp_path: Path) -> None:
     )
 
     with pytest.raises(ValueError):
-        agent.run({"payload": {}})
+        asyncio.run(agent.run({"payload": {}}))
 
 
 def test_candidates_without_valid_properties_are_ignored(tmp_path: Path) -> None:
@@ -198,7 +199,7 @@ def test_candidates_without_valid_properties_are_ignored(tmp_path: Path) -> None
     )
 
     trigger = {"payload": {"company_name": "Example Analytics", "description": "Analytics"}}
-    results = agent.run(trigger)["payload"]["results"]
+    results = asyncio.run(agent.run(trigger))["payload"]["results"]
 
     assert [item["id"] for item in results] == ["valid"]
 
@@ -217,7 +218,7 @@ def test_similar_companies_schema_snapshot(
     monkeypatch.setattr("agents.int_lvl_1_agent.datetime", _FixedDatetime)
 
     trigger = trigger_factory()
-    result = tmp_agent.run(trigger)
+    result = asyncio.run(tmp_agent.run(trigger))
 
     artifact_path = Path(result["payload"]["artifact_path"])
     saved_payload = json.loads(artifact_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- update agent interfaces to use asynchronous run and send contracts and document remaining synchronous human hooks
- adjust research and CRM agent implementations along with orchestrator integration points for coroutine execution
- refresh unit tests to invoke asynchronous agents via asyncio.run and note upcoming await transition in the orchestrator

## Testing
- pytest tests/unit/test_int_lvl_1_agent.py tests/unit/test_dossier_research_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68dc6b227c00832b9eb4a5e4b69fbbf6