### PR TITLE
Refactor integrations to async interfaces

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -30,7 +30,7 @@ surface area that each workflow stage must expose:
 
 | Interface | Required methods | Default implementation |
 |-----------|-----------------|------------------------|
-| `BasePollingAgent` | `poll()`, `poll_contacts()` | [`EventPollingAgent`](event_polling_agent.py) |
+| `BasePollingAgent` | `poll()` *(async)*, `poll_contacts()` | [`EventPollingAgent`](event_polling_agent.py) |
 | `BaseTriggerAgent` | `check(event)` | [`TriggerDetectionAgent`](trigger_detection_agent.py) |
 | `BaseExtractionAgent` | `extract(event)` | [`ExtractionAgent`](extraction_agent.py) |
 | `BaseHumanAgent` | `request_info(event, extracted)`, `request_dossier_confirmation(event, info)` | [`HumanInLoopAgent`](human_in_loop_agent.py) |

--- a/agents/event_polling_agent.py
+++ b/agents/event_polling_agent.py
@@ -58,7 +58,7 @@ class EventPollingAgent(BasePollingAgent):
 
         return False
 
-    async def poll_async(self) -> List[Dict[str, Any]]:
+    async def poll(self) -> List[Dict[str, Any]]:
         """Polls calendar events (read-only) and logs them, skipping birthday entries."""
         try:
             events = await self.calendar.list_events_async(max_results=100)
@@ -77,10 +77,6 @@ class EventPollingAgent(BasePollingAgent):
         except Exception as e:
             logger.error(f"Google Calendar polling failed: {e}")
             raise
-
-    def poll(self) -> Iterable[Dict[str, Any]]:
-        for event in run_async(self.poll_async()):
-            yield event
 
     async def poll_events_async(
         self,

--- a/agents/int_lvl_1_agent.py
+++ b/agents/int_lvl_1_agent.py
@@ -113,7 +113,7 @@ class IntLvl1SimilarCompaniesAgent(BaseResearchAgent):
             or ""
         )
 
-        candidates = self._fetch_candidates(company_name)
+        candidates = await self._fetch_candidates(company_name)
         ranked_results = self._rank_candidates(candidates, target_context)
 
         limited_results = ranked_results[: self._result_limit]
@@ -173,8 +173,8 @@ class IntLvl1SimilarCompaniesAgent(BaseResearchAgent):
         context["description_tokens"] = description_tokens
         return context
 
-    def _fetch_candidates(self, company_name: str) -> Iterable[Mapping[str, Any]]:
-        return self._integration.list_similar_companies(
+    async def _fetch_candidates(self, company_name: str) -> List[Mapping[str, Any]]:
+        return await self._integration.list_similar_companies(
             company_name,
             limit=max(self._result_limit * 3, self._result_limit),
             properties=self.HUBSPOT_PROPERTIES,

--- a/agents/interfaces/base.py
+++ b/agents/interfaces/base.py
@@ -10,7 +10,7 @@ class BasePollingAgent(ABC):
     """Contract for agents that retrieve events from external systems."""
 
     @abstractmethod
-    def poll(self) -> Iterable[Mapping[str, Any]]:
+    async def poll(self) -> Iterable[Mapping[str, Any]]:
         """Yield event payloads that should be processed by the workflow."""
 
     @abstractmethod

--- a/agents/master_workflow_agent.py
+++ b/agents/master_workflow_agent.py
@@ -32,10 +32,11 @@ from agents.local_storage_agent import LocalStorageAgent
 from config.config import settings
 from config.watcher import LlmConfigurationWatcher
 from logs.workflow_log_manager import WorkflowLogManager
-from utils.trigger_loader import load_trigger_words
-from utils.pii import mask_pii
 from utils.audit_log import AuditLog
+from utils.async_http import run_async
 from utils.observability import observe_operation, record_hitl_outcome, record_trigger_match
+from utils.pii import mask_pii
+from utils.trigger_loader import load_trigger_words
 
 logger = logging.getLogger("MasterWorkflowAgent")
 
@@ -172,7 +173,7 @@ class MasterWorkflowAgent:
 
         processed_results: List[Dict[str, Any]] = []
 
-        for event in self.event_agent.poll():
+        for event in run_async(self.event_agent.poll()):
             masked_event = self._mask_for_logging(event)
             logger.info("Polled event: %s", masked_event)
             event_id = event.get("id")

--- a/integration/hubspot_integration.py
+++ b/integration/hubspot_integration.py
@@ -123,7 +123,7 @@ class HubSpotIntegration:
     ) -> Optional[Dict[str, object]]:
         return run_async(self.find_company_by_domain_async(domain, properties=properties))
 
-    async def list_similar_companies_async(
+    async def list_similar_companies(
         self,
         company_name: str,
         *,
@@ -157,21 +157,6 @@ class HubSpotIntegration:
         response_payload = await self._post(self.SEARCH_PATH, payload)
         results: Iterable[Dict[str, object]] = response_payload.get("results", [])
         return list(results)
-
-    def list_similar_companies(
-        self,
-        company_name: str,
-        *,
-        limit: int = 5,
-        properties: Optional[Sequence[str]] = None,
-    ) -> List[Dict[str, object]]:
-        return run_async(
-            self.list_similar_companies_async(
-                company_name,
-                limit=limit,
-                properties=properties,
-            )
-        )
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,14 +59,14 @@ def stub_agent_registry(isolated_agent_registry):
         def __init__(self, *, config=None):
             self.config = config
 
-        def poll(self) -> Iterable[Dict[str, object]]:
-            return iter([
+        async def poll(self) -> Iterable[Dict[str, object]]:
+            return [
                 {
                     "id": "evt-1",
                     "summary": "Test event",
                     "description": "Trigger phrase present",
                 }
-            ])
+            ]
 
         def poll_contacts(self) -> Iterable[Dict[str, object]]:
             return iter(())

--- a/tests/integration/test_hubspot_integration.py
+++ b/tests/integration/test_hubspot_integration.py
@@ -86,7 +86,7 @@ def test_list_similar_companies_uses_normalized_name(monkeypatch, configured_set
 
     monkeypatch.setattr(integration._http, "post", fake_post)
 
-    companies = run_async(integration.list_similar_companies_async(" Acme Corporation "))
+    companies = run_async(integration.list_similar_companies(" Acme Corporation "))
 
     assert len(companies) == 2
     assert companies[0]["id"] == "1"

--- a/tests/test_event_polling_agent.py
+++ b/tests/test_event_polling_agent.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import List
 
@@ -46,7 +47,7 @@ def test_poll_skips_birthday_events(dummy_calendar_events, caplog):
     calendar = DummyCalendar(dummy_calendar_events)
     agent = EventPollingAgent(calendar_integration=calendar)
 
-    polled_events = list(agent.poll())
+    polled_events = asyncio.run(agent.poll())
 
     assert [event["id"] for event in polled_events] == ["1", "5"]
     skipped_logs = [

--- a/tests/test_master_workflow_agent_hard_trigger.py
+++ b/tests/test_master_workflow_agent_hard_trigger.py
@@ -7,7 +7,7 @@ class DummyEventAgent:
     def __init__(self, events: Iterable[Dict[str, Any]]):
         self._events = list(events)
 
-    def poll(self) -> Iterable[Dict[str, Any]]:
+    async def poll(self) -> Iterable[Dict[str, Any]]:
         return list(self._events)
 
 

--- a/tests/test_master_workflow_agent_hitl.py
+++ b/tests/test_master_workflow_agent_hitl.py
@@ -35,9 +35,8 @@ class DummyEventAgent:
     def __init__(self, events: Iterable[Dict[str, Any]]):
         self._events = list(events)
 
-    def poll(self) -> Iterable[Dict[str, Any]]:
-        for event in self._events:
-            yield event
+    async def poll(self) -> Iterable[Dict[str, Any]]:
+        return list(self._events)
 
 
 class DummyTriggerAgent:

--- a/tests/test_observability_smoke.py
+++ b/tests/test_observability_smoke.py
@@ -23,9 +23,8 @@ class DummyEventAgent:
     def __init__(self, events: Iterable[Dict[str, Any]]):
         self._events = list(events)
 
-    def poll(self) -> Iterable[Dict[str, Any]]:
-        for event in self._events:
-            yield event
+    async def poll(self) -> Iterable[Dict[str, Any]]:
+        return list(self._events)
 
 
 class DummyTriggerAgent:

--- a/tests/test_pii_masking.py
+++ b/tests/test_pii_masking.py
@@ -9,8 +9,8 @@ class DummyEventAgent:
     def __init__(self, events: Iterable[Dict[str, Any]]):
         self._events = list(events)
 
-    def poll(self) -> Iterable[Dict[str, Any]]:
-        yield from self._events
+    async def poll(self) -> Iterable[Dict[str, Any]]:
+        return list(self._events)
 
 
 class DummyTriggerAgent:

--- a/tests/unit/test_agent_factory.py
+++ b/tests/unit/test_agent_factory.py
@@ -12,7 +12,7 @@ class DummyPollingAgent(BasePollingAgent):
     def __init__(self, *, token: str = "") -> None:
         self.token = token
 
-    def poll(self):  # pragma: no cover - not exercised in tests
+    async def poll(self):  # pragma: no cover - not exercised in tests
         return []
 
     def poll_contacts(self):  # pragma: no cover - not exercised in tests

--- a/tests/unit/test_int_lvl_1_agent.py
+++ b/tests/unit/test_int_lvl_1_agent.py
@@ -19,7 +19,7 @@ class _StubIntegration:
         self._responses = list(responses)
         self.calls: list[dict[str, object]] = []
 
-    def list_similar_companies(
+    async def list_similar_companies(
         self,
         company_name: str,
         *,


### PR DESCRIPTION
## Summary
- remove the synchronous HubSpot similar companies wrapper and await the async implementation everywhere
- switch the polling agent contract to an async `poll` method and adapt the master workflow to consume it
- update stubs and tests to use async helpers and maintain coverage of the similar companies flow

## Testing
- pytest tests/test_event_polling_agent.py tests/unit/test_int_lvl_1_agent.py tests/test_master_workflow_agent_hard_trigger.py tests/test_master_workflow_agent_hitl.py tests/test_pii_masking.py tests/test_observability_smoke.py tests/integration/test_hubspot_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68dc6d7eb424832ba50c6c6546df1eaf