### PR TITLE
Remove run_async bridge and adopt async workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The orchestrator wires the agents together and coordinates polling, enrichment, 
 python -m agents.workflow_orchestrator
 ```
 
-> **Async migration phase:** `utils.async_http.run_async` is deprecated and will be removed in PR5.
+> **Async orchestration:** The workflow now runs fully asynchronously; call async APIs directly instead of relying on `utils.async_http.run_async`.
 
 Individual agents can also be instantiated and exercised directly for targeted tests or integrations.
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -30,8 +30,8 @@ surface area that each workflow stage must expose:
 
 | Interface | Required methods | Default implementation |
 |-----------|-----------------|------------------------|
-| `BasePollingAgent` | `poll()` *(async)*, `poll_contacts()` | [`EventPollingAgent`](event_polling_agent.py) |
-| `BaseTriggerAgent` | `check(event)` | [`TriggerDetectionAgent`](trigger_detection_agent.py) |
+| `BasePollingAgent` | `poll()` *(async)*, `poll_contacts()` *(async)* | [`EventPollingAgent`](event_polling_agent.py) |
+| `BaseTriggerAgent` | `check(event)` *(async)* | [`TriggerDetectionAgent`](trigger_detection_agent.py) |
 | `BaseExtractionAgent` | `extract(event)` | [`ExtractionAgent`](extraction_agent.py) |
 | `BaseHumanAgent` | `request_info(event, extracted)`, `request_dossier_confirmation(event, info)` | [`HumanInLoopAgent`](human_in_loop_agent.py) |
 | `BaseCrmAgent` | `send(event, info)` | [`LoggingCrmAgent`](crm_agent.py) |

--- a/agents/email_agent.py
+++ b/agents/email_agent.py
@@ -1,11 +1,11 @@
 import logging
+import warnings
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from pathlib import Path
 from typing import Iterable, Optional, Sequence, Union
 
-from utils.async_http import run_async
 from utils.async_smtp import send_email_ssl
 
 
@@ -78,17 +78,15 @@ class EmailAgent:
         attachments: Optional[Sequence[Union[str, Path]]] = None,
         attachment_links: Optional[Iterable[str]] = None,
     ):
-        """Synchronous facade that dispatches to the async implementation."""
+        """Synchronous facade kept for backwards compatibility."""
 
-        return run_async(
-            self.send_email_async(
-                recipient,
-                subject,
-                body,
-                html_body,
-                attachments=attachments,
-                attachment_links=attachment_links,
-            )
+        warnings.warn(
+            "EmailAgent.send_email is deprecated; use send_email_async instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        raise RuntimeError(
+            "EmailAgent.send_email is no longer supported. Use send_email_async instead."
         )
 
     def _normalize_links(self, links: Optional[Iterable[str]]) -> Sequence[str]:

--- a/agents/event_polling_agent.py
+++ b/agents/event_polling_agent.py
@@ -1,11 +1,10 @@
 import logging
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, List, Optional
 
 from agents.factory import register_agent
 from agents.interfaces import BasePollingAgent
 from integration.google_calendar_integration import GoogleCalendarIntegration
 from integration.google_contacts_integration import GoogleContactsIntegration
-from utils.async_http import run_async
 from utils.pii import mask_pii
 
 logger = logging.getLogger(__name__)
@@ -95,24 +94,7 @@ class EventPollingAgent(BasePollingAgent):
             query=query,
         )
 
-    def poll_events(
-        self,
-        start_time,
-        end_time,
-        *,
-        max_results: Optional[int] = None,
-        query: Optional[str] = None,
-    ) -> Iterable[Dict[str, Any]]:
-        return run_async(
-            self.poll_events_async(
-                start_time,
-                end_time,
-                max_results=max_results,
-                query=query,
-            )
-        )
-
-    async def poll_contacts_async(self) -> List[Dict[str, Any]]:
+    async def poll_contacts(self) -> List[Dict[str, Any]]:
         """
         Polls contacts (read-only) and logs them.
         """
@@ -129,6 +111,3 @@ class EventPollingAgent(BasePollingAgent):
         except Exception as e:
             logger.error(f"Google Contacts polling failed: {e}")
             raise
-
-    def poll_contacts(self) -> Iterable[Dict[str, Any]]:
-        return run_async(self.poll_contacts_async())

--- a/agents/interfaces/base.py
+++ b/agents/interfaces/base.py
@@ -14,7 +14,7 @@ class BasePollingAgent(ABC):
         """Yield event payloads that should be processed by the workflow."""
 
     @abstractmethod
-    def poll_contacts(self) -> Iterable[Mapping[str, Any]]:
+    async def poll_contacts(self) -> Iterable[Mapping[str, Any]]:
         """Optionally yield contact payloads associated with the events."""
 
 
@@ -22,7 +22,7 @@ class BaseTriggerAgent(ABC):
     """Contract for agents that detect triggers on events."""
 
     @abstractmethod
-    def check(self, event: Mapping[str, Any]) -> Dict[str, Any]:
+    async def check(self, event: Mapping[str, Any]) -> Dict[str, Any]:
         """Return structured trigger detection information for an event."""
 
 

--- a/agents/workflow_orchestrator.py
+++ b/agents/workflow_orchestrator.py
@@ -56,7 +56,7 @@ class WorkflowOrchestrator:
             self.storage_agent = None
             self._handle_exception(exc, handled=True, context={"phase": "initialisation"})
 
-    def run(self):
+    async def run(self) -> None:
         run_id = generate_run_id()
         with workflow_run(run_id=run_id) as run_context:
             self._last_run_id = run_context.run_id
@@ -73,8 +73,7 @@ class WorkflowOrchestrator:
                 if self.master_agent:
                     if hasattr(self.master_agent, "initialize_run"):
                         self.master_agent.initialize_run(run_context.run_id)
-                    # TODO: Wird in PR3 auf await umgestellt.
-                    results = self.master_agent.process_all_events() or []
+                    results = await self.master_agent.process_all_events() or []
                     self._report_research_errors(run_context.run_id, results)
                     try:
                         self._store_research_outputs(run_context.run_id, results)

--- a/integration/google_calendar_integration.py
+++ b/integration/google_calendar_integration.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import warnings
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional, Sequence, Union
 from urllib import parse
 
 from config.config import Settings
-from utils.async_http import AsyncHTTP, run_async
+from utils.async_http import AsyncHTTP
 
 
 @dataclass
@@ -172,13 +173,13 @@ class GoogleCalendarIntegration:
         max_results: Optional[int] = None,
         query: Optional[str] = None,
     ) -> List[dict]:
-        return run_async(
-            self.fetch_events_async(
-                start_time,
-                end_time,
-                max_results=max_results,
-                query=query,
-            )
+        warnings.warn(
+            "GoogleCalendarIntegration.fetch_events is deprecated; use fetch_events_async instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        raise RuntimeError(
+            "GoogleCalendarIntegration.fetch_events is no longer supported. Use fetch_events_async instead."
         )
 
     async def list_events_async(
@@ -215,15 +216,13 @@ class GoogleCalendarIntegration:
         single_events: bool = True,
         order_by: str = "startTime",
     ) -> List[dict]:
-        return run_async(
-            self.list_events_async(
-                max_results=max_results,
-                time_min=time_min,
-                time_max=time_max,
-                query=query,
-                single_events=single_events,
-                order_by=order_by,
-            )
+        warnings.warn(
+            "GoogleCalendarIntegration.list_events is deprecated; use list_events_async instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        raise RuntimeError(
+            "GoogleCalendarIntegration.list_events is no longer supported. Use list_events_async instead."
         )
 
     async def get_access_token_async(self) -> str:
@@ -233,7 +232,14 @@ class GoogleCalendarIntegration:
         return self._access_token
 
     def get_access_token(self) -> str:
-        return run_async(self.get_access_token_async())
+        warnings.warn(
+            "GoogleCalendarIntegration.get_access_token is deprecated; use get_access_token_async instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        raise RuntimeError(
+            "GoogleCalendarIntegration.get_access_token is no longer supported. Use get_access_token_async instead."
+        )
 
     async def iter_all_events_async(self, time_min: str, time_max: str) -> List[dict]:
         await self._ensure_access_token_async()

--- a/integration/google_contacts_integration.py
+++ b/integration/google_contacts_integration.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import Dict, List, Optional
 
-from utils.async_http import AsyncHTTP, run_async
+import warnings
+
+from utils.async_http import AsyncHTTP
 
 
 class GoogleContactsIntegration:
@@ -43,12 +45,13 @@ class GoogleContactsIntegration:
         person_fields: str = "names,emailAddresses",
         page_token: Optional[str] = None,
     ) -> List[Dict[str, object]]:
-        return run_async(
-            self.list_contacts_async(
-                page_size=page_size,
-                person_fields=person_fields,
-                page_token=page_token,
-            )
+        warnings.warn(
+            "GoogleContactsIntegration.list_contacts is deprecated; use list_contacts_async instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        raise RuntimeError(
+            "GoogleContactsIntegration.list_contacts is no longer supported. Use list_contacts_async instead."
         )
 
     async def aclose(self) -> None:

--- a/integration/hubspot_integration.py
+++ b/integration/hubspot_integration.py
@@ -6,7 +6,9 @@ from dataclasses import dataclass
 from typing import Dict, Iterable, List, Optional, Sequence
 
 from config.config import Settings
-from utils.async_http import AsyncHTTP, run_async
+import warnings
+
+from utils.async_http import AsyncHTTP
 from utils.text_normalization import normalize_text
 
 
@@ -121,7 +123,14 @@ class HubSpotIntegration:
         *,
         properties: Optional[Sequence[str]] = None,
     ) -> Optional[Dict[str, object]]:
-        return run_async(self.find_company_by_domain_async(domain, properties=properties))
+        warnings.warn(
+            "HubSpotIntegration.find_company_by_domain is deprecated; use find_company_by_domain_async instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        raise RuntimeError(
+            "HubSpotIntegration.find_company_by_domain is no longer supported. Use find_company_by_domain_async instead."
+        )
 
     async def list_similar_companies(
         self,

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ import asyncio
 from dotenv import load_dotenv
 
 
-async def main() -> None:
+async def _async_main() -> None:
     load_dotenv()
 
     import logging
@@ -23,8 +23,12 @@ async def main() -> None:
     )
 
     orchestrator = WorkflowOrchestrator()
-    orchestrator.run()
+    await orchestrator.run()
+
+
+def main() -> None:
+    asyncio.run(_async_main())
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,14 +68,14 @@ def stub_agent_registry(isolated_agent_registry):
                 }
             ]
 
-        def poll_contacts(self) -> Iterable[Dict[str, object]]:
-            return iter(())
+        async def poll_contacts(self) -> Iterable[Dict[str, object]]:
+            return []
 
     class StubTriggerAgent(BaseTriggerAgent):
         def __init__(self, *, trigger_words=None):
             self.trigger_words = trigger_words or []
 
-        def check(self, event: Dict[str, object]) -> Dict[str, object]:
+        async def check(self, event: Dict[str, object]) -> Dict[str, object]:
             return {
                 "trigger": True,
                 "type": "soft",
@@ -118,14 +118,14 @@ def stub_agent_registry(isolated_agent_registry):
         def __init__(self):
             self.sent: list[Dict[str, object]] = []
 
-        def send(self, event: Dict[str, object], info: Dict[str, object]) -> None:
+        async def send(self, event: Dict[str, object], info: Dict[str, object]) -> None:
             self.sent.append({"event": event, "info": info})
 
     class StubInternalResearchAgent(BaseResearchAgent):
         def __init__(self, *, config: Any = None):
             self.config = config
 
-        def run(self, trigger: Dict[str, Any]) -> Dict[str, Any]:
+        async def run(self, trigger: Dict[str, Any]) -> Dict[str, Any]:
             return {
                 "agent": "internal_research",
                 "status": "REPORT_REQUIRED",
@@ -139,7 +139,7 @@ def stub_agent_registry(isolated_agent_registry):
         def __init__(self, *, config: Any = None):
             self.config = config
 
-        def run(self, trigger: Dict[str, Any]) -> Dict[str, Any]:
+        async def run(self, trigger: Dict[str, Any]) -> Dict[str, Any]:
             return {
                 "agent": "dossier_research",
                 "status": "completed",
@@ -151,7 +151,7 @@ def stub_agent_registry(isolated_agent_registry):
         def __init__(self, *, config: Any = None):
             self.config = config
 
-        def run(self, trigger: Dict[str, Any]) -> Dict[str, Any]:
+        async def run(self, trigger: Dict[str, Any]) -> Dict[str, Any]:
             return {
                 "agent": "similar_companies_level1",
                 "status": "completed",

--- a/tests/integration/test_hubspot_integration.py
+++ b/tests/integration/test_hubspot_integration.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 from typing import Dict, List
 
+import asyncio
+
 import pytest
 
 from config.config import Settings
 from integration.hubspot_integration import HubSpotIntegration
-from utils.async_http import run_async
 
 
 class DummyResponse:
@@ -63,7 +64,9 @@ def test_find_company_by_domain_normalizes_and_matches(monkeypatch, configured_s
 
     monkeypatch.setattr(integration._http, "post", fake_post)
 
-    result = run_async(integration.find_company_by_domain_async("HTTPS://Example.com/"))
+    result = asyncio.run(
+        integration.find_company_by_domain_async("HTTPS://Example.com/")
+    )
 
     assert result == response_payload["results"][0]
     assert captured_payloads, "Expected HubSpot request payload to be captured"
@@ -86,7 +89,9 @@ def test_list_similar_companies_uses_normalized_name(monkeypatch, configured_set
 
     monkeypatch.setattr(integration._http, "post", fake_post)
 
-    companies = run_async(integration.list_similar_companies(" Acme Corporation "))
+    companies = asyncio.run(
+        integration.list_similar_companies(" Acme Corporation ")
+    )
 
     assert len(companies) == 2
     assert companies[0]["id"] == "1"

--- a/tests/stubs/opentelemetry/sdk/trace/export/__init__.py
+++ b/tests/stubs/opentelemetry/sdk/trace/export/__init__.py
@@ -1,10 +1,9 @@
 """Span exporters and processors for the stub tracing SDK."""
 
 from __future__ import annotations
-
 """Span exporter utilities for the in-repo OpenTelemetry shim."""
 
-from typing import Iterable, List
+from typing import Iterable, List  # noqa: E402
 
 __all__ = [
     "SpanExporter",

--- a/tests/test_event_polling_agent.py
+++ b/tests/test_event_polling_agent.py
@@ -65,9 +65,11 @@ def test_agent_uses_public_fetch_events(mocker):
 
     agent = EventPollingAgent(calendar_integration=integration)
 
-    events = agent.poll_events(
-        "2025-01-01T00:00:00Z",
-        "2025-01-02T00:00:00Z",
+    events = asyncio.run(
+        agent.poll_events_async(
+            "2025-01-01T00:00:00Z",
+            "2025-01-02T00:00:00Z",
+        )
     )
 
     integration.fetch_events_async.assert_awaited_once_with(
@@ -88,5 +90,5 @@ def test_poll_contacts_uses_async_flow(dummy_calendar_events, mocker):
         contacts_integration=contacts,
     )
 
-    contacts_result = agent.poll_contacts()
+    contacts_result = asyncio.run(agent.poll_contacts())
     assert contacts_result == [{"resourceName": "people/1"}]

--- a/tests/test_master_workflow_agent_hard_trigger.py
+++ b/tests/test_master_workflow_agent_hard_trigger.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any, Dict, Iterable
 
 from agents.master_workflow_agent import MasterWorkflowAgent
@@ -15,7 +16,7 @@ class DummyTriggerAgent:
     def __init__(self, result: Dict[str, Any]):
         self._result = result
 
-    def check(self, _event: Dict[str, Any]) -> Dict[str, Any]:
+    async def check(self, _event: Dict[str, Any]) -> Dict[str, Any]:
         return dict(self._result)
 
 
@@ -39,7 +40,7 @@ def test_hard_trigger_with_complete_info_dispatches_without_unhandled_state() ->
 
     dispatched: Dict[str, Any] = {"called": False}
 
-    def _fake_process_crm_dispatch(
+    async def _fake_process_crm_dispatch(
         _event: Dict[str, Any],
         _info: Dict[str, Any],
         event_result: Dict[str, Any],
@@ -55,7 +56,7 @@ def test_hard_trigger_with_complete_info_dispatches_without_unhandled_state() ->
     agent._process_crm_dispatch = _fake_process_crm_dispatch  # type: ignore[assignment]
 
     try:
-        results = agent.process_all_events()
+        results = asyncio.run(agent.process_all_events())
     finally:
         agent.finalize_run_logs()
 

--- a/tests/test_observability_smoke.py
+++ b/tests/test_observability_smoke.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any, Dict, Iterable
 
 import json
@@ -31,7 +32,7 @@ class DummyTriggerAgent:
     def __init__(self, result: Dict[str, Any]):
         self._result = result
 
-    def check(self, _event: Dict[str, Any]) -> Dict[str, Any]:
+    async def check(self, _event: Dict[str, Any]) -> Dict[str, Any]:
         return self._result
 
 
@@ -173,7 +174,7 @@ def test_observability_records_metrics_and_traces(monkeypatch, tmp_path):
             str(tmp_path / "similar_results.json")
         )
 
-        orchestrator.run()
+        asyncio.run(orchestrator.run())
 
         assert crm_agent.sent, "CRM agent should have been invoked"
 

--- a/tests/test_pii_masking.py
+++ b/tests/test_pii_masking.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any, Dict, Iterable
 
 from agents.master_workflow_agent import MasterWorkflowAgent
@@ -17,7 +18,7 @@ class DummyTriggerAgent:
     def __init__(self, trigger_type: str = "hard") -> None:
         self._trigger_type = trigger_type
 
-    def check(self, _event: Dict[str, Any]) -> Dict[str, Any]:
+    async def check(self, _event: Dict[str, Any]) -> Dict[str, Any]:
         return {
             "trigger": True,
             "type": self._trigger_type,
@@ -98,7 +99,7 @@ def test_master_agent_masks_logged_events(tmp_path):
             extraction_agent=DummyExtractionAgent(),
         )
 
-        agent.process_all_events()
+        asyncio.run(agent.process_all_events())
 
         log_text = agent.log_file_path.read_text(encoding="utf-8")
         assert "organizer@example.com" not in log_text
@@ -146,7 +147,7 @@ def test_human_agent_masks_messages(tmp_path):
             extraction_agent=DummyExtractionAgent(),
         )
 
-        agent.process_all_events()
+        asyncio.run(agent.process_all_events())
 
         assert backend.requests, "Backend should receive a request"
         message = backend.requests[0]["message"]

--- a/tests/test_workflow_orchestrator_alerts.py
+++ b/tests/test_workflow_orchestrator_alerts.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from agents.alert_agent import AlertSeverity
 from agents.workflow_orchestrator import WorkflowOrchestrator
 
@@ -23,7 +25,7 @@ class StubMasterAgent:
         self.log_file_path = "stub.log"
         self.storage_agent = None
 
-    def process_all_events(self):
+    async def process_all_events(self):
         self.process_calls += 1
         if self.fail_process:
             raise RuntimeError("processing error")
@@ -41,7 +43,7 @@ def test_orchestrator_emits_alert_on_handled_exception():
         master_agent=master_agent,
     )
 
-    orchestrator.run()
+    asyncio.run(orchestrator.run())
 
     assert len(alert_agent.calls) == 1
     call = alert_agent.calls[0]
@@ -59,8 +61,8 @@ def test_orchestrator_escalates_alert_on_repeated_failures():
         failure_threshold=2,
     )
 
-    orchestrator.run()
-    orchestrator.run()
+    asyncio.run(orchestrator.run())
+    asyncio.run(orchestrator.run())
 
     assert len(alert_agent.calls) == 2
     first, second = alert_agent.calls

--- a/tests/unit/test_agent_factory.py
+++ b/tests/unit/test_agent_factory.py
@@ -15,7 +15,7 @@ class DummyPollingAgent(BasePollingAgent):
     async def poll(self):  # pragma: no cover - not exercised in tests
         return []
 
-    def poll_contacts(self):  # pragma: no cover - not exercised in tests
+    async def poll_contacts(self):  # pragma: no cover - not exercised in tests
         return []
 
 

--- a/utils/async_http.py
+++ b/utils/async_http.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import Any, Mapping, Optional
 
@@ -10,6 +9,8 @@ import httpx
 
 import tenacity
 from tenacity import retry, retry_if_exception_type, stop_after_attempt
+
+from .retry import DEFAULT_MAX_ATTEMPTS, INITIAL_BACKOFF_SECONDS, MAX_BACKOFF_SECONDS
 
 _wait_random_exponential = getattr(tenacity, "wait_random_exponential", None)
 if _wait_random_exponential is None:
@@ -21,12 +22,7 @@ if _wait_random_exponential is None:
 else:
     wait_random_exponential = _wait_random_exponential
 
-from .retry import DEFAULT_MAX_ATTEMPTS, INITIAL_BACKOFF_SECONDS, MAX_BACKOFF_SECONDS
-
 logger = logging.getLogger(__name__)
-
-_RUN_ASYNC_DEPRECATION_MESSAGE = "run_async deprecated, removal in PR5"
-_run_async_warning_emitted = False
 
 DEFAULT_CONNECT_TIMEOUT = 5.0
 DEFAULT_READ_TIMEOUT = 20.0
@@ -111,23 +107,3 @@ class AsyncHTTP:
 
     async def delete(self, url: str, **kw: Any) -> httpx.Response:
         return await self.request("DELETE", url, **kw)
-
-
-def run_async(coro):
-    """Execute an async coroutine from synchronous code."""
-    global _run_async_warning_emitted
-
-    if not _run_async_warning_emitted:
-        logger.warning(_RUN_ASYNC_DEPRECATION_MESSAGE)
-        _run_async_warning_emitted = True
-
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        loop = None
-
-    if loop and loop.is_running():
-        raise RuntimeError(
-            "Cannot run coroutine synchronously while an event loop is running"
-        )
-    return asyncio.run(coro)

--- a/utils/async_smtp.py
+++ b/utils/async_smtp.py
@@ -8,6 +8,8 @@ import aiosmtplib
 import tenacity
 from tenacity import retry, retry_if_exception_type, stop_after_attempt
 
+from .retry import DEFAULT_MAX_ATTEMPTS, INITIAL_BACKOFF_SECONDS, MAX_BACKOFF_SECONDS
+
 _wait_random_exponential = getattr(tenacity, "wait_random_exponential", None)
 if _wait_random_exponential is None:
     from tenacity import wait_exponential_jitter
@@ -17,8 +19,6 @@ if _wait_random_exponential is None:
 
 else:
     wait_random_exponential = _wait_random_exponential
-
-from .retry import DEFAULT_MAX_ATTEMPTS, INITIAL_BACKOFF_SECONDS, MAX_BACKOFF_SECONDS
 
 DEFAULT_SMTP_PORT = 465
 DEFAULT_TIMEOUT = 20.0


### PR DESCRIPTION
## Summary
- remove the deprecated utils.async_http.run_async helper and drop legacy sync facades across integrations
- convert master workflow orchestration and trigger detection to fully async flows while updating event polling and orchestration helpers
- refresh docs and tests to reflect the async APIs and deprecations

## Testing
- `ruff check .`
- `mypy --explicit-package-bases .` *(fails: existing repository type errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68dc70cca4fc832b82b5a04c7e7e07c0