### PR TITLE
Implement concurrency limiting for HubSpot and research tasks

### DIFF
--- a/agents/master_workflow_agent.py
+++ b/agents/master_workflow_agent.py
@@ -678,9 +678,7 @@ class MasterWorkflowAgent:
             await runners[0]()
             return
 
-        async with asyncio.TaskGroup() as group:
-            for runner in runners:
-                group.create_task(runner())
+        await concurrency.run_in_task_group(runners)
 
     def _can_run_dossier(self, info: Dict[str, Any]) -> bool:
         return bool(info.get("company_name")) and bool(info.get("company_domain"))

--- a/agents/master_workflow_agent.py
+++ b/agents/master_workflow_agent.py
@@ -1,6 +1,5 @@
 """MasterWorkflowAgent: Pure logic agent for polling and event-processing."""
 
-import asyncio
 import json
 import logging
 from datetime import datetime, timezone

--- a/config/config.py
+++ b/config/config.py
@@ -262,6 +262,12 @@ class Settings:
         self.hubspot_retry_backoff_seconds: float = _get_float_env(
             "HUBSPOT_RETRY_BACKOFF_SECONDS", 1.0
         )
+        self.max_concurrent_hubspot: int = max(
+            1, _get_int_env("MAX_CONCURRENT_HUBSPOT", 5)
+        )
+        self.max_concurrent_research: int = max(
+            1, _get_int_env("MAX_CONCURRENT_RESEARCH", 3)
+        )
 
         self.agent_log_dir: Path
         self.research_artifact_dir: Path

--- a/tests/unit/test_master_workflow_agent_concurrency.py
+++ b/tests/unit/test_master_workflow_agent_concurrency.py
@@ -1,6 +1,11 @@
 import asyncio
 from typing import Any, Dict, Optional
 
+try:  # Python 3.11+
+    ExceptionGroup
+except NameError:  # pragma: no cover - Python 3.10 fallback
+    from types import ExceptionGroup  # type: ignore[attr-defined]
+
 import pytest
 
 from agents.master_workflow_agent import MasterWorkflowAgent

--- a/tests/unit/test_master_workflow_agent_concurrency.py
+++ b/tests/unit/test_master_workflow_agent_concurrency.py
@@ -4,7 +4,15 @@ from typing import Any, Dict, Optional
 try:  # Python 3.11+
     from builtins import ExceptionGroup  # type: ignore[attr-defined]
 except ImportError:  # pragma: no cover - Python 3.10 fallback
-    from types import ExceptionGroup  # type: ignore[attr-defined]
+    try:
+        from types import ExceptionGroup  # type: ignore[attr-defined]
+    except ImportError:  # pragma: no cover - minimal backport fallback
+        class ExceptionGroup(Exception):  # type: ignore[override]
+            """Simplified ExceptionGroup shim for Python 3.10 tests."""
+
+            def __init__(self, message: str, exceptions: Any) -> None:
+                super().__init__(message)
+                self.exceptions = list(exceptions)
 
 import pytest
 

--- a/tests/unit/test_master_workflow_agent_concurrency.py
+++ b/tests/unit/test_master_workflow_agent_concurrency.py
@@ -1,22 +1,10 @@
 import asyncio
 from typing import Any, Dict, Optional
 
-try:  # Python 3.11+
-    from builtins import ExceptionGroup  # type: ignore[attr-defined]
-except ImportError:  # pragma: no cover - Python 3.10 fallback
-    try:
-        from types import ExceptionGroup  # type: ignore[attr-defined]
-    except ImportError:  # pragma: no cover - minimal backport fallback
-        class ExceptionGroup(Exception):  # type: ignore[override]
-            """Simplified ExceptionGroup shim for Python 3.10 tests."""
-
-            def __init__(self, message: str, exceptions: Any) -> None:
-                super().__init__(message)
-                self.exceptions = list(exceptions)
-
 import pytest
 
 from agents.master_workflow_agent import MasterWorkflowAgent
+from utils.concurrency import ExceptionGroup
 
 
 def _build_synthetic_agent() -> MasterWorkflowAgent:

--- a/tests/unit/test_master_workflow_agent_concurrency.py
+++ b/tests/unit/test_master_workflow_agent_concurrency.py
@@ -1,0 +1,62 @@
+import asyncio
+from typing import Any, Dict, Optional
+
+import pytest
+
+from agents.master_workflow_agent import MasterWorkflowAgent
+
+
+def _build_synthetic_agent() -> MasterWorkflowAgent:
+    agent = MasterWorkflowAgent.__new__(MasterWorkflowAgent)
+    agent.dossier_research_agent = object()
+    agent.similar_companies_agent = object()
+    agent._log_research_step = lambda *args, **kwargs: None  # type: ignore[attr-defined]
+    agent._can_run_dossier = lambda info: True  # type: ignore[attr-defined]
+    agent._can_run_similar = lambda info: True  # type: ignore[attr-defined]
+    return agent  # type: ignore[return-value]
+
+
+def test_taskgroup_cancels_parallel_tasks_on_failure() -> None:
+    agent = _build_synthetic_agent()
+
+    cancelled: Dict[str, bool] = {"similar": False}
+
+    async def fake_run(
+        _agent: Optional[Any],
+        agent_name: str,
+        event_result: Dict[str, Any],
+        event: Dict[str, Any],
+        info: Dict[str, Any],
+        event_id: Optional[Any],
+        *,
+        force: bool,
+    ) -> None:
+        if agent_name == "dossier_research":
+            await asyncio.sleep(0.05)
+            raise RuntimeError("boom")
+        if agent_name == "similar_companies":
+            try:
+                await asyncio.sleep(0.2)
+            except asyncio.CancelledError:
+                cancelled["similar"] = True
+                raise
+
+    agent._run_research_agent = fake_run  # type: ignore[assignment]
+
+    event_result: Dict[str, Any] = {"research": {}}
+    event: Dict[str, Any] = {"id": "evt-123"}
+    info = {"company_name": "Example", "company_domain": "example.com"}
+
+    with pytest.raises(ExceptionGroup) as exc_info:
+        asyncio.run(
+            agent._execute_precrm_research(  # type: ignore[attr-defined]
+                event_result,
+                event,
+                info,
+                event_id=event["id"],
+                requires_dossier=True,
+            )
+        )
+
+    assert any(isinstance(err, RuntimeError) for err in exc_info.value.exceptions)
+    assert cancelled["similar"] is True

--- a/tests/unit/test_master_workflow_agent_concurrency.py
+++ b/tests/unit/test_master_workflow_agent_concurrency.py
@@ -2,8 +2,8 @@ import asyncio
 from typing import Any, Dict, Optional
 
 try:  # Python 3.11+
-    ExceptionGroup
-except NameError:  # pragma: no cover - Python 3.10 fallback
+    from builtins import ExceptionGroup  # type: ignore[attr-defined]
+except ImportError:  # pragma: no cover - Python 3.10 fallback
     from types import ExceptionGroup  # type: ignore[attr-defined]
 
 import pytest

--- a/utils/concurrency.py
+++ b/utils/concurrency.py
@@ -22,6 +22,12 @@ except ImportError:  # pragma: no cover - Python 3.10 fallback
                 super().__init__(message)
                 self.exceptions = list(exceptions)
 
+    # Ensure subsequent imports via ``builtins`` observe the fallback class.
+    import builtins as _builtins
+
+    if getattr(_builtins, "ExceptionGroup", None) is None:  # pragma: no cover - sanity guard
+        _builtins.ExceptionGroup = ExceptionGroup  # type: ignore[attr-defined]
+
 _DEFAULT_HUBSPOT_LIMIT = 5
 _DEFAULT_RESEARCH_LIMIT = 3
 
@@ -229,6 +235,7 @@ def reload_limits(
 
 
 __all__ = [
+    "ExceptionGroup",
     "HUBSPOT_SEMAPHORE",
     "LoggingSemaphore",
     "RESEARCH_TASK_SEMAPHORE",

--- a/utils/concurrency.py
+++ b/utils/concurrency.py
@@ -1,0 +1,168 @@
+"""Asynchronous concurrency primitives for external service coordination."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_HUBSPOT_LIMIT = 5
+_DEFAULT_RESEARCH_LIMIT = 3
+
+
+class LoggingSemaphore:
+    """Semaphore wrapper that logs concurrent acquisitions at debug level."""
+
+    def __init__(self, name: str, limit: int) -> None:
+        self._name = name
+        self._limit = max(1, int(limit))
+        self._semaphore = asyncio.Semaphore(self._limit)
+        self._lock = asyncio.Lock()
+        self._active = 0
+
+    async def __aenter__(self) -> "LoggingSemaphore":
+        await self._semaphore.acquire()
+        async with self._lock:
+            self._active += 1
+            logger.debug(
+                "%s concurrency acquired (%d/%d)",
+                self._name,
+                self._active,
+                self._limit,
+            )
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> Optional[bool]:
+        async with self._lock:
+            self._active = max(0, self._active - 1)
+            logger.debug(
+                "%s concurrency released (%d/%d)",
+                self._name,
+                self._active,
+                self._limit,
+            )
+        self._semaphore.release()
+        return None
+
+    @property
+    def limit(self) -> int:
+        return self._limit
+
+    @property
+    def active(self) -> int:
+        return self._active
+
+
+def _resolve_limit(env_name: str, default: int) -> int:
+    raw_value = os.getenv(env_name)
+    if raw_value is None:
+        return default
+
+    try:
+        value = int(raw_value)
+    except ValueError:
+        logger.warning(
+            "Invalid value for %s: expected integer but received %r. Using default %d.",
+            env_name,
+            raw_value,
+            default,
+        )
+        return default
+
+    if value < 1:
+        logger.warning(
+            "%s must be greater than zero; received %d. Using default %d.",
+            env_name,
+            value,
+            default,
+        )
+        return default
+
+    return value
+
+
+def _normalise_limit(value: Optional[int], *, fallback: int, name: str) -> int:
+    if value is None:
+        return fallback
+
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid override for %s: expected integer but received %r. Keeping %d.",
+            name,
+            value,
+            fallback,
+        )
+        return fallback
+
+    if coerced < 1:
+        logger.warning(
+            "%s override must be positive; received %d. Keeping %d.",
+            name,
+            coerced,
+            fallback,
+        )
+        return fallback
+
+    return coerced
+
+
+_HUBSPOT_LIMIT = _resolve_limit("MAX_CONCURRENT_HUBSPOT", _DEFAULT_HUBSPOT_LIMIT)
+_RESEARCH_LIMIT = _resolve_limit("MAX_CONCURRENT_RESEARCH", _DEFAULT_RESEARCH_LIMIT)
+
+HUBSPOT_SEMAPHORE = LoggingSemaphore("hubspot", _HUBSPOT_LIMIT)
+RESEARCH_TASK_SEMAPHORE = LoggingSemaphore("research", _RESEARCH_LIMIT)
+
+
+def reload_limits(
+    *, hubspot: Optional[int] = None, research: Optional[int] = None
+) -> None:
+    """Reconfigure concurrency limits at runtime.
+
+    Primarily intended for tests where environment variables are modified on the
+    fly. When no explicit overrides are provided the current limits remain
+    unchanged.
+    """
+
+    global HUBSPOT_SEMAPHORE, RESEARCH_TASK_SEMAPHORE, _HUBSPOT_LIMIT, _RESEARCH_LIMIT
+
+    resolved_hubspot = _normalise_limit(
+        hubspot,
+        fallback=_resolve_limit("MAX_CONCURRENT_HUBSPOT", _HUBSPOT_LIMIT),
+        name="MAX_CONCURRENT_HUBSPOT",
+    )
+    resolved_research = _normalise_limit(
+        research,
+        fallback=_resolve_limit("MAX_CONCURRENT_RESEARCH", _RESEARCH_LIMIT),
+        name="MAX_CONCURRENT_RESEARCH",
+    )
+
+    if resolved_hubspot != _HUBSPOT_LIMIT:
+        logger.info(
+            "Updating HubSpot concurrency limit from %d to %d",
+            _HUBSPOT_LIMIT,
+            resolved_hubspot,
+        )
+    if resolved_research != _RESEARCH_LIMIT:
+        logger.info(
+            "Updating research concurrency limit from %d to %d",
+            _RESEARCH_LIMIT,
+            resolved_research,
+        )
+
+    _HUBSPOT_LIMIT = resolved_hubspot
+    _RESEARCH_LIMIT = resolved_research
+    HUBSPOT_SEMAPHORE = LoggingSemaphore("hubspot", _HUBSPOT_LIMIT)
+    RESEARCH_TASK_SEMAPHORE = LoggingSemaphore("research", _RESEARCH_LIMIT)
+
+
+__all__ = [
+    "HUBSPOT_SEMAPHORE",
+    "LoggingSemaphore",
+    "RESEARCH_TASK_SEMAPHORE",
+    "reload_limits",
+]


### PR DESCRIPTION
## Summary
- add a reusable concurrency module with logging semaphores and runtime reconfiguration
- wrap HubSpot API requests in the shared semaphore and timeout guard while exposing new MAX_CONCURRENT_* settings
- execute dossier and similar company research in parallel TaskGroups with shared research concurrency limits and new tests

## Testing
- `pytest tests/integration/test_hubspot_integration.py tests/unit/test_master_workflow_agent_concurrency.py`


------
https://chatgpt.com/codex/tasks/task_e_68dc760042f8832bb2e94b48d8730be7