### PR TITLE
Implement orchestrator shutdown lifecycle

### DIFF
--- a/agents/event_polling_agent.py
+++ b/agents/event_polling_agent.py
@@ -111,3 +111,15 @@ class EventPollingAgent(BasePollingAgent):
         except Exception as e:
             logger.error(f"Google Contacts polling failed: {e}")
             raise
+
+    async def aclose(self) -> None:
+        """Release underlying integration clients."""
+
+        calendar_close = getattr(self.calendar, "aclose", None)
+        if callable(calendar_close):
+            await calendar_close()
+
+        if self.contacts is not None:
+            contacts_close = getattr(self.contacts, "aclose", None)
+            if callable(contacts_close):
+                await contacts_close()

--- a/agents/workflow_orchestrator.py
+++ b/agents/workflow_orchestrator.py
@@ -1,23 +1,28 @@
-"""
-WorkflowOrchestrator: Central orchestrator for the Agentic Intelligence Research workflow.
+"""WorkflowOrchestrator: Central orchestrator for the Agentic Intelligence Research workflow."""
 
-- Controls the full workflow (polling, trigger detection, extraction, HITL, CRM, persistence).
-- Handles logging, error handling, status, and retries.
-- Calls the MasterWorkflowAgent and sub-agents as pure logic modules.
-"""
-
+import asyncio
 import json
 import logging
+import signal
+import time
 from pathlib import Path
-from typing import Any, Dict, Mapping, Optional, Sequence, Union
+from typing import Any, Awaitable, Callable, Dict, Mapping, Optional, Sequence, Set, Union
 
 from agents.alert_agent import AlertAgent, AlertSeverity
 from agents.master_workflow_agent import MasterWorkflowAgent
 from config.config import settings
-from utils.observability import configure_observability, generate_run_id, workflow_run
+from utils.observability import (
+    configure_observability,
+    flush_telemetry,
+    generate_run_id,
+    workflow_run,
+)
 from utils.reporting import convert_research_artifacts_to_pdfs
 
 logger = logging.getLogger("WorkflowOrchestrator")
+
+
+DEFAULT_SHUTDOWN_TIMEOUT = 5.0
 
 
 class WorkflowOrchestrator:
@@ -38,6 +43,21 @@ class WorkflowOrchestrator:
         self._last_run_id: Optional[str] = None
         self._research_summary_root = Path(settings.research_artifact_dir) / "workflow_runs"
 
+        self._background_tasks: Set[asyncio.Task[Any]] = set()
+        self._async_cleanups: list[tuple[str, Callable[[], Awaitable[None]]]] = []
+        self._sync_cleanups: list[tuple[str, Callable[[], None]]] = []
+        self._shutdown_lock: Optional[asyncio.Lock] = None
+        self._shutdown_started = False
+        self._shutdown_complete = False
+        self._shutdown_event: Optional[asyncio.Event] = None
+        timeout_setting = getattr(settings, "shutdown_timeout_seconds", DEFAULT_SHUTDOWN_TIMEOUT)
+        try:
+            self._shutdown_timeout = max(0.1, float(timeout_setting))
+        except (TypeError, ValueError):
+            self._shutdown_timeout = DEFAULT_SHUTDOWN_TIMEOUT
+        self._last_run_summary: Dict[str, Any] = {}
+        self._current_run_started_at: Optional[float] = None
+
         configure_observability()
 
         try:
@@ -47,6 +67,9 @@ class WorkflowOrchestrator:
             )
             self.log_filename = self.master_agent.log_filename
             self.storage_agent = getattr(self.master_agent, "storage_agent", None)
+            closer = getattr(self.master_agent, "aclose", None)
+            if callable(closer):
+                self._register_async_cleanup("master_agent", closer)
         except EnvironmentError as exc:
             # Missing env/config is expected in some (e.g., test) environments.
             logger.error("Failed to initialise MasterWorkflowAgent: %s", exc)
@@ -56,54 +79,243 @@ class WorkflowOrchestrator:
             self.storage_agent = None
             self._handle_exception(exc, handled=True, context={"phase": "initialisation"})
 
-    async def run(self) -> None:
-        run_id = generate_run_id()
-        with workflow_run(run_id=run_id) as run_context:
-            self._last_run_id = run_context.run_id
-            logger.info("Workflow orchestrator started.")
+    def _register_async_cleanup(
+        self, label: str, closer: Callable[[], Awaitable[None]]
+    ) -> None:
+        self._async_cleanups.append((label, closer))
 
-            if self._init_error is not None:
-                logger.warning(
-                    "Workflow orchestrator initialisation skipped due to configuration error."
-                )
-                run_context.mark_status("skipped")
-                return
+    def _register_sync_cleanup(self, label: str, closer: Callable[[], None]) -> None:
+        self._sync_cleanups.append((label, closer))
+
+    def _ensure_shutdown_primitives(self) -> tuple[asyncio.Lock, asyncio.Event]:
+        if self._shutdown_lock is None or self._shutdown_event is None:
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError as exc:  # pragma: no cover - defensive guard
+                raise RuntimeError(
+                    "WorkflowOrchestrator shutdown requires an active event loop"
+                ) from exc
+
+            if self._shutdown_lock is None:
+                self._shutdown_lock = asyncio.Lock()
+            if self._shutdown_event is None:
+                self._shutdown_event = asyncio.Event()
+
+        return self._shutdown_lock, self._shutdown_event
+
+    def track_background_task(self, task: asyncio.Task[Any]) -> asyncio.Task[Any]:
+        """Track *task* for cooperative cancellation during shutdown."""
+
+        if task.done():
+            return task
+
+        self._background_tasks.add(task)
+
+        def _discard(completed: asyncio.Task[Any]) -> None:
+            self._background_tasks.discard(completed)
+
+        task.add_done_callback(_discard)
+        return task
+
+    def install_signal_handlers(
+        self, loop: Optional[asyncio.AbstractEventLoop] = None
+    ) -> None:
+        """Install POSIX signal handlers that trigger a graceful shutdown."""
+
+        try:
+            loop = loop or asyncio.get_running_loop()
+        except RuntimeError:
+            return
+
+        if not hasattr(loop, "add_signal_handler"):
+            return
+
+        for signal_name in ("SIGTERM", "SIGINT"):
+            sig = getattr(signal, signal_name, None)
+            if sig is None:
+                continue
 
             try:
-                if self.master_agent:
-                    if hasattr(self.master_agent, "initialize_run"):
-                        self.master_agent.initialize_run(run_context.run_id)
-                    results = await self.master_agent.process_all_events() or []
-                    self._report_research_errors(run_context.run_id, results)
+                loop.add_signal_handler(
+                    sig,
+                    lambda s=sig: loop.create_task(
+                        self.shutdown(reason=f"signal:{getattr(s, 'name', str(s))}")
+                    ),
+                )
+            except (NotImplementedError, RuntimeError):
+                # Windows / non-main threads may not support signal handlers.
+                continue
+
+    def _update_run_summary(
+        self,
+        run_context,
+        events_processed: int,
+        duration_seconds: float,
+    ) -> None:
+        if run_context is None:
+            return
+
+        self._last_run_summary = {
+            "run_id": run_context.run_id,
+            "status": run_context.status,
+            "events_processed": events_processed,
+            "duration_seconds": max(0.0, duration_seconds),
+        }
+
+    def _log_run_manifest(self) -> None:
+        if not self._last_run_summary:
+            return
+
+        summary = self._last_run_summary
+        logger.info(
+            "Run manifest: run_id=%s status=%s events=%s duration=%.3fs",
+            summary.get("run_id"),
+            summary.get("status"),
+            summary.get("events_processed"),
+            summary.get("duration_seconds", 0.0),
+        )
+
+    async def shutdown(self, *, reason: str = "manual", timeout: Optional[float] = None) -> None:
+        """Gracefully release resources and cancel background activity."""
+
+        try:
+            resolved_timeout = (
+                self._shutdown_timeout
+                if timeout is None
+                else max(0.1, float(timeout))
+            )
+        except (TypeError, ValueError):
+            resolved_timeout = self._shutdown_timeout
+
+        lock, event = self._ensure_shutdown_primitives()
+
+        wait_for_completion: Optional[asyncio.Event] = None
+        async with lock:
+            if self._shutdown_complete:
+                return
+            if self._shutdown_started:
+                wait_for_completion = event
+            else:
+                self._shutdown_started = True
+
+        if wait_for_completion is not None:
+            await wait_for_completion.wait()
+            return
+
+        logger.info("Initiating orchestrator shutdown (reason=%s)", reason)
+
+        try:
+            pending_tasks = [task for task in self._background_tasks if not task.done()]
+            if pending_tasks:
+                logger.debug("Cancelling %d background task(s)", len(pending_tasks))
+                for task in pending_tasks:
+                    task.cancel()
+                try:
+                    results = await asyncio.wait_for(
+                        asyncio.gather(*pending_tasks, return_exceptions=True),
+                        timeout=resolved_timeout,
+                    )
+                    for result in results:
+                        if isinstance(result, BaseException) and not isinstance(
+                            result, asyncio.CancelledError
+                        ):
+                            logger.warning(
+                                "Background task exited with exception during shutdown: %s",
+                                result,
+                            )
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "Timed out waiting for %d background task(s) to cancel.",
+                        len(pending_tasks),
+                    )
+
+            for label, closer in list(self._async_cleanups):
+                try:
+                    await asyncio.wait_for(closer(), timeout=resolved_timeout)
+                except asyncio.TimeoutError:
+                    logger.warning("Timed out closing resource %s", label)
+                except Exception:
+                    logger.exception("Error closing resource %s", label)
+
+            for label, closer in list(self._sync_cleanups):
+                try:
+                    closer()
+                except Exception:
+                    logger.exception("Error closing synchronous resource %s", label)
+
+            try:
+                await flush_telemetry(timeout=resolved_timeout)
+            except Exception:
+                logger.exception("Failed to flush observability telemetry during shutdown")
+
+            self._log_run_manifest()
+            logger.info("Orchestrator shutdown complete.")
+        finally:
+            self._background_tasks.clear()
+            self._async_cleanups.clear()
+            self._sync_cleanups.clear()
+            self._shutdown_complete = True
+            event.set()
+
+    async def run(self) -> None:
+        run_id = generate_run_id()
+        events_processed = 0
+        run_context = None
+        start_time = time.perf_counter()
+        self._current_run_started_at = start_time
+
+        try:
+            with workflow_run(run_id=run_id) as context:
+                run_context = context
+                self._last_run_id = context.run_id
+                logger.info("Workflow orchestrator started.")
+
+                if self._init_error is not None or not self.master_agent:
+                    logger.warning(
+                        "Workflow orchestrator initialisation skipped due to configuration error."
+                    )
+                    context.mark_status("skipped")
+                else:
                     try:
-                        self._store_research_outputs(run_context.run_id, results)
-                    except Exception as exc:  # pragma: no cover - defensive guard
-                        logger.error(
-                            "Failed to persist research outputs", exc_info=True
-                        )
+                        if hasattr(self.master_agent, "initialize_run"):
+                            self.master_agent.initialize_run(context.run_id)
+
+                        results = await self.master_agent.process_all_events() or []
+                        events_processed = len(results)
+                        self._report_research_errors(context.run_id, results)
+                        try:
+                            self._store_research_outputs(context.run_id, results)
+                        except Exception as exc:  # pragma: no cover - defensive guard
+                            logger.error(
+                                "Failed to persist research outputs", exc_info=True
+                            )
+                            self._handle_exception(
+                                exc,
+                                handled=True,
+                                context={
+                                    "phase": "store_research",
+                                    "run_id": context.run_id,
+                                },
+                            )
+                    except Exception as exc:
+                        context.mark_failure(exc)
+                        logger.exception("Workflow failed with exception:")
                         self._handle_exception(
                             exc,
-                            handled=True,
-                            context={
-                                "phase": "store_research",
-                                "run_id": run_context.run_id,
-                            },
+                            handled=False,
+                            context={"phase": "run"},
+                            track_failure=True,
                         )
-            except Exception as exc:
-                run_context.mark_failure(exc)
-                logger.exception("Workflow failed with exception:")
-                self._handle_exception(
-                    exc,
-                    handled=False,
-                    context={"phase": "run"},
-                    track_failure=True,
-                )
-            else:
-                run_context.mark_success()
-                logger.info("Workflow completed successfully.")
-                self._reset_failure_count(self._failure_key)
-            finally:
-                self._finalize()
+                    else:
+                        context.mark_success()
+                        logger.info("Workflow completed successfully.")
+                        self._reset_failure_count(self._failure_key)
+        finally:
+            self._finalize()
+            duration = time.perf_counter() - start_time
+            self._current_run_started_at = None
+            self._update_run_summary(run_context, events_processed, duration)
+            self._log_run_manifest()
 
     def _store_research_outputs(
         self, run_id: str, results: Sequence[Dict[str, object]]

--- a/main.py
+++ b/main.py
@@ -23,7 +23,11 @@ async def _async_main() -> None:
     )
 
     orchestrator = WorkflowOrchestrator()
-    await orchestrator.run()
+    orchestrator.install_signal_handlers(asyncio.get_running_loop())
+    try:
+        await orchestrator.run()
+    finally:
+        await orchestrator.shutdown()
 
 
 def main() -> None:

--- a/tests/integration/test_workflow_orchestrator_integration.py
+++ b/tests/integration/test_workflow_orchestrator_integration.py
@@ -88,7 +88,10 @@ async def test_backend_failure_triggers_alert(
         alert_agent=alert_agent, master_agent=master_agent, failure_threshold=3
     )
 
-    await orchestrator.run()
+    try:
+        await orchestrator.run()
+    finally:
+        await orchestrator.shutdown()
 
     assert alert_agent.calls
     call = alert_agent.calls[-1]
@@ -115,8 +118,11 @@ async def test_repeated_failures_escalate_to_critical(
         alert_agent=alert_agent, master_agent=master_agent, failure_threshold=2
     )
 
-    await orchestrator.run()
-    await orchestrator.run()
+    try:
+        await orchestrator.run()
+        await orchestrator.run()
+    finally:
+        await orchestrator.shutdown()
 
     assert len(alert_agent.calls) == 2
     first, second = alert_agent.calls
@@ -263,7 +269,10 @@ async def test_orchestrator_records_research_artifacts_and_email_details(
     master_agent = RecordingMasterAgent(log_dir=log_dir, results=research_results)
 
     orchestrator = WorkflowOrchestrator(master_agent=master_agent)
-    await orchestrator.run()
+    try:
+        await orchestrator.run()
+    finally:
+        await orchestrator.shutdown()
 
     run_id = orchestrator._last_run_id
     assert run_id is not None

--- a/tests/test_observability_smoke.py
+++ b/tests/test_observability_smoke.py
@@ -178,7 +178,10 @@ async def test_observability_records_metrics_and_traces(
             str(tmp_path / "similar_results.json")
         )
 
-        await orchestrator.run()
+        try:
+            await orchestrator.run()
+        finally:
+            await orchestrator.shutdown()
 
         assert crm_agent.sent, "CRM agent should have been invoked"
 

--- a/tests/test_workflow_orchestrator_alerts.py
+++ b/tests/test_workflow_orchestrator_alerts.py
@@ -48,7 +48,10 @@ async def test_orchestrator_emits_alert_on_handled_exception():
         master_agent=master_agent,
     )
 
-    await orchestrator.run()
+    try:
+        await orchestrator.run()
+    finally:
+        await orchestrator.shutdown()
 
     assert len(alert_agent.calls) == 1
     call = alert_agent.calls[0]
@@ -66,8 +69,11 @@ async def test_orchestrator_escalates_alert_on_repeated_failures():
         failure_threshold=2,
     )
 
-    await orchestrator.run()
-    await orchestrator.run()
+    try:
+        await orchestrator.run()
+        await orchestrator.run()
+    finally:
+        await orchestrator.shutdown()
 
     assert len(alert_agent.calls) == 2
     first, second = alert_agent.calls

--- a/tests/test_workflow_orchestrator_shutdown.py
+++ b/tests/test_workflow_orchestrator_shutdown.py
@@ -1,0 +1,94 @@
+import asyncio
+from pathlib import Path
+
+import pytest
+
+import agents.workflow_orchestrator as orchestrator_module
+from agents.workflow_orchestrator import WorkflowOrchestrator
+
+
+try:  # pragma: no cover - optional async plugin handling
+    import pytest_asyncio  # type: ignore  # noqa: F401
+except ImportError:  # pragma: no cover - fallback to anyio marker
+    pytestmark = pytest.mark.anyio
+
+    @pytest.fixture
+    def anyio_backend():  # pragma: no cover - ensure asyncio backend under anyio
+        return "asyncio"
+else:
+    pytestmark = pytest.mark.asyncio
+
+
+class _DummyResource:
+    def __init__(self) -> None:
+        self.close_calls = 0
+
+    async def aclose(self) -> None:
+        self.close_calls += 1
+
+
+class _StubMasterAgent:
+    def __init__(self, log_dir: Path) -> None:
+        self._resource = _DummyResource()
+        self.log_file_path = log_dir / "stub.log"
+        self.log_file_path.write_text("", encoding="utf-8")
+        self.log_filename = str(self.log_file_path)
+        self.storage_agent = None
+        self.closed = False
+
+    def initialize_run(self, run_id: str) -> None:  # pragma: no cover - stub hook
+        return
+
+    async def process_all_events(self):
+        return []
+
+    def finalize_run_logs(self) -> None:  # pragma: no cover - stub hook
+        return
+
+    async def aclose(self) -> None:
+        self.closed = True
+        await self._resource.aclose()
+
+
+async def test_shutdown_cancels_tasks_and_flushes(monkeypatch, tmp_path: Path) -> None:
+    master_agent = _StubMasterAgent(tmp_path)
+    orchestrator = WorkflowOrchestrator(master_agent=master_agent)
+
+    flush_calls: list[float] = []
+
+    async def fake_flush(timeout: float = 0.0) -> None:
+        flush_calls.append(timeout)
+
+    monkeypatch.setattr(orchestrator_module, "flush_telemetry", fake_flush)
+
+    await orchestrator.run()
+
+    blocker = asyncio.Event()
+    task = orchestrator.track_background_task(asyncio.create_task(blocker.wait()))
+
+    await orchestrator.shutdown(reason="test", timeout=0.1)
+
+    assert task.cancelled()
+    assert master_agent.closed is True
+    assert master_agent._resource.close_calls == 1  # type: ignore[attr-defined]
+    assert flush_calls, "flush_telemetry should have been invoked"
+
+
+async def test_shutdown_is_idempotent(monkeypatch, tmp_path: Path) -> None:
+    master_agent = _StubMasterAgent(tmp_path)
+    orchestrator = WorkflowOrchestrator(master_agent=master_agent)
+
+    flush_calls = 0
+
+    async def fake_flush(timeout: float = 0.0) -> None:
+        nonlocal flush_calls
+        flush_calls += 1
+
+    monkeypatch.setattr(orchestrator_module, "flush_telemetry", fake_flush)
+
+    await orchestrator.shutdown()
+    await orchestrator.shutdown()
+
+    assert master_agent.closed is True
+    assert master_agent._resource.close_calls == 1  # type: ignore[attr-defined]
+    assert flush_calls == 1


### PR DESCRIPTION
## Summary
- add structured shutdown management to `WorkflowOrchestrator`, including background task cancellation, resource cleanup, signal handling, and final run summaries
- extend agents and entrypoints to expose async close methods, wire graceful shutdown into the CLI, and flush telemetry providers
- harden tests to await orchestrator shutdown and add new coverage for shutdown behaviour

## Testing
- `pytest tests/test_workflow_orchestrator_shutdown.py`


------
https://chatgpt.com/codex/tasks/task_e_68dcf36c621c832b975b6be07f3a6616