### PR TITLE
Refactor email workflows to async interfaces

### DIFF
--- a/agents/email_agent.py
+++ b/agents/email_agent.py
@@ -1,6 +1,4 @@
-import asyncio
 import logging
-import warnings
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -69,43 +67,6 @@ class EmailAgent:
             logging.error(f"Failed to send email to {recipient}: {e}")
             return False
 
-    def send_email(
-        self,
-        recipient,
-        subject,
-        body,
-        html_body=None,
-        *,
-        attachments: Optional[Sequence[Union[str, Path]]] = None,
-        attachment_links: Optional[Iterable[str]] = None,
-    ):
-        """Synchronous facade kept for backwards compatibility."""
-
-        warnings.warn(
-            "EmailAgent.send_email is deprecated; use send_email_async instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-        try:
-            return asyncio.run(
-                self.send_email_async(
-                    recipient,
-                    subject,
-                    body,
-                    html_body=html_body,
-                    attachments=attachments,
-                    attachment_links=attachment_links,
-                )
-            )
-        except RuntimeError as exc:
-            if "asyncio.run() cannot be called" in str(exc):
-                raise RuntimeError(
-                    "EmailAgent.send_email cannot be invoked while an event loop is running. "
-                    "Call send_email_async instead."
-                ) from exc
-            raise
-
     def _normalize_links(self, links: Optional[Iterable[str]]) -> Sequence[str]:
         if not links:
             return []
@@ -168,4 +129,4 @@ class EmailAgent:
 # Example usage:
 # agent = EmailAgent("smtp.example.com", 465, "user", "pass",
 # "noreply@example.com")
-# agent.send_email("recipient@example.com", "Subject", "Body")
+# await agent.send_email_async("recipient@example.com", "Subject", "Body")

--- a/agents/human_in_loop_agent.py
+++ b/agents/human_in_loop_agent.py
@@ -449,10 +449,10 @@ class HumanInLoopAgent(BaseHumanAgent):
         backend = self.communication_backend
         if backend is None:
             return None
-        if hasattr(backend, "send_email"):
+        if hasattr(backend, "send_email_async"):
             return backend
         candidate = getattr(backend, "email_agent", None)
-        if candidate is not None and hasattr(candidate, "send_email"):
+        if candidate is not None and hasattr(candidate, "send_email_async"):
             return candidate
         return None
 

--- a/tests/unit/test_email_agent.py
+++ b/tests/unit/test_email_agent.py
@@ -15,7 +15,10 @@ def _install_dummy_async_smtp(monkeypatch: pytest.MonkeyPatch, sent_messages: Li
     monkeypatch.setattr("agents.email_agent.send_email_ssl", fake_send_email_ssl)
 
 
-def test_email_agent_attaches_pdfs_and_links(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.asyncio
+async def test_email_agent_attaches_pdfs_and_links(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     attachment = tmp_path / "report.pdf"
     attachment.write_bytes(b"%PDF-1.4 test")
 
@@ -25,7 +28,7 @@ def test_email_agent_attaches_pdfs_and_links(tmp_path: Path, monkeypatch: pytest
     agent = EmailAgent("smtp.example.com", 465, "user", "pass", "sender@example.com")
     portal_link = "https://crm.example.com/attachments/run-123/report"
 
-    result = agent.send_email(
+    result = await agent.send_email_async(
         "recipient@example.com",
         "Subject",
         "Body text",
@@ -52,13 +55,16 @@ def test_email_agent_attaches_pdfs_and_links(tmp_path: Path, monkeypatch: pytest
     assert portal_link in html_part.get_content()
 
 
-def test_email_agent_handles_missing_attachments_gracefully(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.asyncio
+async def test_email_agent_handles_missing_attachments_gracefully(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     sent_messages: List[str] = []
     _install_dummy_async_smtp(monkeypatch, sent_messages)
 
     agent = EmailAgent("smtp.example.com", 465, "user", "pass", "sender@example.com")
 
-    result = agent.send_email(
+    result = await agent.send_email_async(
         "recipient@example.com",
         "Subject",
         "Simple body",


### PR DESCRIPTION
## Summary
- drop the synchronous `EmailAgent.send_email` entrypoint and rely exclusively on `send_email_async`
- update reminder/escalation orchestration and alert dispatching to schedule async email sends, including internal research flows
- adjust reminder and alert unit tests to exercise the coroutine-based email APIs

## Testing
- pytest *(fails: async test plugin not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcfdbb4c00832b80663192cc8c3181