### PR TITLE
Refactor extraction workflow to async extraction agents

### DIFF
--- a/agents/extraction_agent.py
+++ b/agents/extraction_agent.py
@@ -21,11 +21,8 @@ class ExtractionAgent(BaseExtractionAgent):
     def __init__(self):
         pass
 
-    def extract(self, event: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Extracts the company name and web domain from the event data.
-        Returns a dictionary with the extracted info and a completeness flag.
-        """
+    async def extract(self, event: Dict[str, Any]) -> Dict[str, Any]:
+        """Asynchronously extract company metadata from the event payload."""
         try:
             # Notes:
             # Try to find company name in a dedicated field first, fallback to searching in summary or description.

--- a/agents/interfaces/base.py
+++ b/agents/interfaces/base.py
@@ -30,8 +30,12 @@ class BaseExtractionAgent(ABC):
     """Contract for agents that extract structured information from events."""
 
     @abstractmethod
-    def extract(self, event: Mapping[str, Any]) -> Dict[str, Any]:
-        """Return structured information extracted from an event payload."""
+    async def extract(self, event: Mapping[str, Any]) -> Dict[str, Any]:
+        """Return structured information extracted from an event payload.
+
+        Implementations must be defined as async coroutines so callers can
+        `await` extraction even when the underlying work is synchronous.
+        """
 
 
 class BaseHumanAgent(ABC):

--- a/agents/master_workflow_agent.py
+++ b/agents/master_workflow_agent.py
@@ -233,7 +233,7 @@ class MasterWorkflowAgent:
                     for field in ("summary", "description"):
                         if field not in extraction_input and context.get(field) is not None:
                             extraction_input[field] = context.get(field)
-                extracted = self.extraction_agent.extract(extraction_input)
+                extracted = await self.extraction_agent.extract(extraction_input)
             event_result["extraction"] = extracted
 
             info = extracted.get("info", {}) or {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,7 +95,7 @@ def stub_agent_registry(isolated_agent_registry):
             }
 
     class StubExtractionAgent(BaseExtractionAgent):
-        def extract(self, event: Dict[str, object]) -> Dict[str, object]:
+        async def extract(self, event: Dict[str, object]) -> Dict[str, object]:
             return {
                 "info": {
                     "company_name": "Example Co",

--- a/tests/test_master_workflow_agent_hard_trigger.py
+++ b/tests/test_master_workflow_agent_hard_trigger.py
@@ -30,7 +30,7 @@ class DummyExtractionAgent:
     def __init__(self, response: Dict[str, Any]):
         self._response = response
 
-    def extract(self, _event: Dict[str, Any]) -> Dict[str, Any]:
+    async def extract(self, _event: Dict[str, Any]) -> Dict[str, Any]:
         return dict(self._response)
 
 

--- a/tests/test_master_workflow_agent_hitl.py
+++ b/tests/test_master_workflow_agent_hitl.py
@@ -58,7 +58,7 @@ class DummyExtractionAgent:
     def __init__(self, response: Dict[str, Any]):
         self._response = response
 
-    def extract(self, _event: Dict[str, Any]) -> Dict[str, Any]:
+    async def extract(self, _event: Dict[str, Any]) -> Dict[str, Any]:
         return self._response
 
 

--- a/tests/test_observability_smoke.py
+++ b/tests/test_observability_smoke.py
@@ -42,7 +42,7 @@ class DummyExtractionAgent:
     def __init__(self, response: Dict[str, Any]):
         self._response = response
 
-    def extract(self, _event: Dict[str, Any]) -> Dict[str, Any]:
+    async def extract(self, _event: Dict[str, Any]) -> Dict[str, Any]:
         return self._response
 
 

--- a/tests/test_pii_masking.py
+++ b/tests/test_pii_masking.py
@@ -35,7 +35,7 @@ class DummyTriggerAgent:
 
 
 class DummyExtractionAgent:
-    def extract(self, event: Dict[str, Any]) -> Dict[str, Any]:
+    async def extract(self, event: Dict[str, Any]) -> Dict[str, Any]:
         return {"info": {"company_name": "Example", "contact_name": "Ada"}, "is_complete": True}
 
 


### PR DESCRIPTION
## Summary
- convert the extraction agent interface and default implementation to async coroutines
- await extraction results inside the master workflow agent
- update fixtures and workflow tests to use async extraction stubs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd0290caf4832bbc88e2a770e4f882