### PR TITLE
Ensure run_id is set before orchestrator startup

### DIFF
--- a/tests/test_main_logging.py
+++ b/tests/test_main_logging.py
@@ -34,7 +34,7 @@ def test_init_logging_injects_default_run_id(capsys):
         "log message emitted before orchestrator instantiation"
     )
     captured = capsys.readouterr()
-    assert "run_id=n/a" in captured.err
+    assert "run_id=unassigned" in captured.err
 
 
 def test_logging_filter_respects_existing_run_id(capsys):

--- a/tests/test_master_workflow_agent_hard_trigger.py
+++ b/tests/test_master_workflow_agent_hard_trigger.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Iterable
 import pytest
 
 from agents.master_workflow_agent import MasterWorkflowAgent
+from utils.observability import current_run_id_var, generate_run_id
 
 
 pytestmark = pytest.mark.asyncio
@@ -43,6 +44,10 @@ async def test_hard_trigger_with_complete_info_dispatches_without_unhandled_stat
         trigger_agent=DummyTriggerAgent({"trigger": True, "type": "hard"}),
         extraction_agent=DummyExtractionAgent({"info": info, "is_complete": True}),
     )
+
+    run_id = generate_run_id()
+    current_run_id_var.set(run_id)
+    agent.attach_run(run_id, agent.workflow_log_manager)
 
     dispatched: Dict[str, Any] = {"called": False}
 

--- a/tests/test_master_workflow_agent_hitl.py
+++ b/tests/test_master_workflow_agent_hitl.py
@@ -6,6 +6,7 @@ import pytest
 
 from agents.master_workflow_agent import MasterWorkflowAgent
 from config.config import settings
+from utils.observability import current_run_id_var, generate_run_id
 
 
 pytestmark = pytest.mark.asyncio
@@ -89,6 +90,9 @@ def _prepare_agent(backend: DummyBackend) -> MasterWorkflowAgent:
         agent._send_calls.append({"event": to_event, "info": event_info})
 
     agent._send_to_crm_agent = _capture_send  # type: ignore[assignment]
+    run_id = generate_run_id()
+    current_run_id_var.set(run_id)
+    agent.attach_run(run_id, agent.workflow_log_manager)
     return agent
 
 
@@ -254,6 +258,10 @@ async def test_audit_log_records_missing_info_flow(tmp_path) -> None:
             agent._send_calls.append({"event": to_event, "info": event_info})
 
         agent._send_to_crm_agent = _capture_send  # type: ignore[assignment]
+
+        run_id = generate_run_id()
+        current_run_id_var.set(run_id)
+        agent.attach_run(run_id, agent.workflow_log_manager)
 
         await agent.process_all_events()
 

--- a/tests/test_pii_masking.py
+++ b/tests/test_pii_masking.py
@@ -7,6 +7,7 @@ import pytest
 
 from agents.master_workflow_agent import MasterWorkflowAgent
 from config.config import settings
+from utils.observability import current_run_id_var, generate_run_id
 from utils.pii import mask_pii
 
 
@@ -106,6 +107,10 @@ async def test_master_agent_masks_logged_events(orchestrator_environment):
             extraction_agent=DummyExtractionAgent(),
         )
 
+        run_id = generate_run_id()
+        current_run_id_var.set(run_id)
+        agent.attach_run(run_id, agent.workflow_log_manager)
+
         await agent.process_all_events()
 
         log_text = agent.log_file_path.read_text(encoding="utf-8")
@@ -153,6 +158,10 @@ async def test_human_agent_masks_messages(orchestrator_environment):
             trigger_agent=DummyTriggerAgent("soft"),
             extraction_agent=DummyExtractionAgent(),
         )
+
+        run_id = generate_run_id()
+        current_run_id_var.set(run_id)
+        agent.attach_run(run_id, agent.workflow_log_manager)
 
         await agent.process_all_events()
 

--- a/tests/test_workflow_orchestrator_alerts.py
+++ b/tests/test_workflow_orchestrator_alerts.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import pytest
 
+import pytest
+
 from agents.alert_agent import AlertSeverity
 from agents.workflow_orchestrator import WorkflowOrchestrator
+from utils.observability import current_run_id_var, generate_run_id
 
 
 pytestmark = pytest.mark.asyncio
@@ -29,6 +32,11 @@ class StubMasterAgent:
         self.log_filename = "stub.log"
         self.log_file_path = "stub.log"
         self.storage_agent = None
+        self.run_ids: list[str] = []
+        self.workflow_log_manager = None
+
+    def attach_run(self, run_id: str, *_args, **_kwargs) -> None:
+        self.run_ids.append(run_id)
 
     async def process_all_events(self):
         self.process_calls += 1
@@ -43,15 +51,19 @@ class StubMasterAgent:
 async def test_orchestrator_emits_alert_on_handled_exception():
     alert_agent = DummyAlertAgent()
     master_agent = StubMasterAgent(fail_finalize=True)
+    run_id = generate_run_id()
+    token = current_run_id_var.set(run_id)
     orchestrator = WorkflowOrchestrator(
         alert_agent=alert_agent,
         master_agent=master_agent,
+        run_id=run_id,
     )
 
     try:
         await orchestrator.run()
     finally:
         await orchestrator.shutdown()
+        current_run_id_var.reset(token)
 
     assert len(alert_agent.calls) == 1
     call = alert_agent.calls[0]
@@ -63,10 +75,13 @@ async def test_orchestrator_emits_alert_on_handled_exception():
 async def test_orchestrator_escalates_alert_on_repeated_failures():
     alert_agent = DummyAlertAgent()
     master_agent = StubMasterAgent(fail_process=True)
+    run_id = generate_run_id()
+    token = current_run_id_var.set(run_id)
     orchestrator = WorkflowOrchestrator(
         alert_agent=alert_agent,
         master_agent=master_agent,
         failure_threshold=2,
+        run_id=run_id,
     )
 
     try:
@@ -74,6 +89,7 @@ async def test_orchestrator_escalates_alert_on_repeated_failures():
         await orchestrator.run()
     finally:
         await orchestrator.shutdown()
+        current_run_id_var.reset(token)
 
     assert len(alert_agent.calls) == 2
     first, second = alert_agent.calls

--- a/tests/test_workflow_orchestrator_shutdown.py
+++ b/tests/test_workflow_orchestrator_shutdown.py
@@ -3,8 +3,14 @@ from pathlib import Path
 
 import pytest
 
+import asyncio
+from pathlib import Path
+
+import pytest
+
 import agents.workflow_orchestrator as orchestrator_module
 from agents.workflow_orchestrator import WorkflowOrchestrator
+from utils.observability import current_run_id_var, generate_run_id
 
 
 try:  # pragma: no cover - optional async plugin handling
@@ -35,9 +41,11 @@ class _StubMasterAgent:
         self.log_filename = str(self.log_file_path)
         self.storage_agent = None
         self.closed = False
+        self.run_ids: list[str] = []
+        self.workflow_log_manager = None
 
-    def initialize_run(self, run_id: str) -> None:  # pragma: no cover - stub hook
-        return
+    def attach_run(self, run_id: str, *_args, **_kwargs) -> None:  # pragma: no cover - stub hook
+        self.run_ids.append(run_id)
 
     async def process_all_events(self):
         return []
@@ -52,21 +60,26 @@ class _StubMasterAgent:
 
 async def test_shutdown_cancels_tasks_and_flushes(monkeypatch, tmp_path: Path) -> None:
     master_agent = _StubMasterAgent(tmp_path)
-    orchestrator = WorkflowOrchestrator(master_agent=master_agent)
+    run_id = generate_run_id()
+    token = current_run_id_var.set(run_id)
+    try:
+        orchestrator = WorkflowOrchestrator(master_agent=master_agent, run_id=run_id)
 
-    flush_calls: list[float] = []
+        flush_calls: list[float] = []
 
-    async def fake_flush(timeout: float = 0.0) -> None:
-        flush_calls.append(timeout)
+        async def fake_flush(timeout: float = 0.0) -> None:
+            flush_calls.append(timeout)
 
-    monkeypatch.setattr(orchestrator_module, "flush_telemetry", fake_flush)
+        monkeypatch.setattr(orchestrator_module, "flush_telemetry", fake_flush)
 
-    await orchestrator.run()
+        await orchestrator.run()
 
-    blocker = asyncio.Event()
-    task = orchestrator.track_background_task(asyncio.create_task(blocker.wait()))
+        blocker = asyncio.Event()
+        task = orchestrator.track_background_task(asyncio.create_task(blocker.wait()))
 
-    await orchestrator.shutdown(reason="test", timeout=0.1)
+        await orchestrator.shutdown(reason="test", timeout=0.1)
+    finally:
+        current_run_id_var.reset(token)
 
     assert task.cancelled()
     assert master_agent.closed is True
@@ -76,19 +89,24 @@ async def test_shutdown_cancels_tasks_and_flushes(monkeypatch, tmp_path: Path) -
 
 async def test_shutdown_is_idempotent(monkeypatch, tmp_path: Path) -> None:
     master_agent = _StubMasterAgent(tmp_path)
-    orchestrator = WorkflowOrchestrator(master_agent=master_agent)
+    run_id = generate_run_id()
+    token = current_run_id_var.set(run_id)
+    try:
+        orchestrator = WorkflowOrchestrator(master_agent=master_agent, run_id=run_id)
 
-    flush_calls = 0
+        flush_calls = 0
 
-    async def fake_flush(timeout: float = 0.0) -> None:
-        nonlocal flush_calls
-        flush_calls += 1
+        async def fake_flush(timeout: float = 0.0) -> None:
+            nonlocal flush_calls
+            flush_calls += 1
 
-    monkeypatch.setattr(orchestrator_module, "flush_telemetry", fake_flush)
+        monkeypatch.setattr(orchestrator_module, "flush_telemetry", fake_flush)
 
-    await orchestrator.shutdown()
-    await orchestrator.shutdown()
+        await orchestrator.shutdown()
+        await orchestrator.shutdown()
 
-    assert master_agent.closed is True
-    assert master_agent._resource.close_calls == 1  # type: ignore[attr-defined]
-    assert flush_calls == 1
+        assert master_agent.closed is True
+        assert master_agent._resource.close_calls == 1  # type: ignore[attr-defined]
+        assert flush_calls == 1
+    finally:
+        current_run_id_var.reset(token)


### PR DESCRIPTION
## Summary
- generate and register a run identifier before constructing the workflow orchestrator and reuse it across daemon cycles
- refactor observability and orchestration code to consume the pre-assigned run_id for logging and tracing
- update master workflow agent helpers and tests to attach runs explicitly and expect the new run_id defaults

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfc5c0e4f4832bb1771a93845f0c3b