### PR TITLE
Implement negative cache for unchanged events

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -23,6 +23,16 @@ environments. For a visual overview of how these agents collaborate, refer to
 | [`trigger_detection_agent.py`](trigger_detection_agent.py) | Detects hard and soft trigger phrases in event summaries and descriptions using normalised keyword matching. |
 | [`workflow_orchestrator.py`](workflow_orchestrator.py) | High-level orchestrator that initialises the `MasterWorkflowAgent`, handles error resilience, and finalises runs by recording local log metadata. |
 
+## Negative cache for unchanged events
+
+The `MasterWorkflowAgent` persists a lightweight "negative cache" in
+`<RUN_LOG_DIR>/state/negative_cache.json`. Each cache entry stores a fingerprint of
+the event payload, the trigger word rule hash, and the last classification decision.
+During subsequent runs, events whose fingerprints, trigger rules, and classification
+version remain unchanged are skipped before trigger detection. Entries automatically
+expire after 30 days or when the calendar event is updated, ensuring that modified
+events are reprocessed without manual intervention.
+
 ## Extension points
 
 Reusable abstract base classes live in [`interfaces/`](interfaces). They define the minimum

--- a/tests/test_master_workflow_agent_negative_cache.py
+++ b/tests/test_master_workflow_agent_negative_cache.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List
+
+import pytest
+
+from agents.master_workflow_agent import MasterWorkflowAgent
+from config.config import settings
+from utils.observability import current_run_id_var, generate_run_id
+
+
+pytestmark = pytest.mark.asyncio
+
+
+class StubEventAgent:
+    def __init__(self, events: Iterable[Dict[str, Any]]):
+        self._events = [dict(event) for event in events]
+
+    async def poll(self) -> List[Dict[str, Any]]:
+        return [dict(event) for event in self._events]
+
+
+class StubTriggerAgent:
+    def __init__(self, result: Dict[str, Any]):
+        self._result = dict(result)
+
+    async def check(self, _event: Dict[str, Any]) -> Dict[str, Any]:
+        return dict(self._result)
+
+
+class StubExtractionAgent:
+    async def extract(self, _event: Dict[str, Any]) -> Dict[str, Any]:
+        return {"info": {}, "is_complete": False}
+
+
+async def _run_agent(
+    events: Iterable[Dict[str, Any]],
+    *,
+    trigger_result: Dict[str, Any],
+) -> List[Dict[str, Any]]:
+    agent = MasterWorkflowAgent(
+        event_agent=StubEventAgent(events),
+        trigger_agent=StubTriggerAgent(trigger_result),
+        extraction_agent=StubExtractionAgent(),
+    )
+
+    run_id = generate_run_id()
+    current_run_id_var.set(run_id)
+    agent.attach_run(run_id, agent.workflow_log_manager)
+
+    try:
+        return await agent.process_all_events()
+    finally:
+        agent.finalize_run_logs()
+
+
+async def test_negative_cache_skips_and_reprocesses(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run_dir = tmp_path / "runs"
+    workflow_dir = tmp_path / "workflow"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    workflow_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(settings, "run_log_dir", run_dir)
+    monkeypatch.setattr(settings, "workflow_log_dir", workflow_dir)
+
+    base_event = {
+        "id": "evt-1",
+        "summary": "Quarterly sync",
+        "description": "Discuss roadmap",
+    }
+    trigger_result = {"trigger": False, "confidence": 0.99}
+
+    first_run = await _run_agent([base_event], trigger_result=trigger_result)
+    assert first_run[0]["status"] == "no_trigger"
+
+    second_run = await _run_agent([base_event], trigger_result=trigger_result)
+    assert second_run[0]["status"] == "skipped_negative_cache"
+
+    updated_event = dict(base_event)
+    updated_event["summary"] = "Quarterly sync updated"
+
+    third_run = await _run_agent([updated_event], trigger_result=trigger_result)
+    assert third_run[0]["status"] == "no_trigger"

--- a/tests/unit/test_negative_cache.py
+++ b/tests/unit/test_negative_cache.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from utils.negative_cache import NegativeEventCache
+
+
+def _set_time(monkeypatch: pytest.MonkeyPatch, value: float) -> None:
+    monkeypatch.setattr("utils.negative_cache.time.time", lambda: value)
+
+
+def _make_event(summary: str = "Kick-off", description: str = "") -> dict[str, str]:
+    return {"id": "evt-1", "summary": summary, "description": description}
+
+
+def test_should_skip_returns_true_when_fingerprint_and_rule_hash_match(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_path = tmp_path / "cache.json"
+    cache = NegativeEventCache.load(cache_path, rule_hash="hash", now=0)
+    event = _make_event()
+    _set_time(monkeypatch, 100.0)
+    cache.record_no_trigger(event, "hash", "no_trigger")
+
+    assert cache.should_skip(event, "hash") is True
+
+
+def test_should_skip_false_when_rule_hash_changes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_path = tmp_path / "cache.json"
+    cache = NegativeEventCache.load(cache_path, rule_hash="hash", now=0)
+    event = _make_event()
+    _set_time(monkeypatch, 50.0)
+    cache.record_no_trigger(event, "hash", "no_trigger")
+
+    assert cache.should_skip(event, "other") is False
+
+
+def test_should_skip_false_when_fingerprint_changes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_path = tmp_path / "cache.json"
+    cache = NegativeEventCache.load(cache_path, rule_hash="hash", now=0)
+    event = _make_event()
+    _set_time(monkeypatch, 10.0)
+    cache.record_no_trigger(event, "hash", "no_trigger")
+
+    changed = _make_event(summary="Updated")
+    assert cache.should_skip(changed, "hash") is False
+
+
+def test_record_and_forget_removes_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_path = tmp_path / "cache.json"
+    cache = NegativeEventCache.load(cache_path, rule_hash="hash", now=0)
+    event = _make_event()
+    _set_time(monkeypatch, 20.0)
+    cache.record_no_trigger(event, "hash", "no_trigger")
+
+    cache.forget("evt-1")
+    assert cache.should_skip(event, "hash") is False
+
+
+def test_purge_stale_removes_old_entries(tmp_path: Path) -> None:
+    cache_path = tmp_path / "cache.json"
+    raw = {
+        "version": 1,
+        "entries": {
+            "evt-old": {
+                "fingerprint": "abc",
+                "updated": "2000-01-01T00:00:00Z",
+                "rule_hash": "hash",
+                "decision": "no_trigger",
+                "first_seen": 0,
+                "last_seen": 0,
+                "classification_version": "v1",
+            },
+            "evt-last-seen": {
+                "fingerprint": "def",
+                "updated": None,
+                "rule_hash": "hash",
+                "decision": "no_trigger",
+                "first_seen": 0,
+                "last_seen": 0,
+                "classification_version": "v1",
+            },
+        },
+    }
+    cache_path.write_text(json.dumps(raw), encoding="utf-8")
+
+    reference_now = datetime(2024, 1, 1, tzinfo=timezone.utc).timestamp()
+    cache = NegativeEventCache.load(
+        cache_path, rule_hash="hash", now=reference_now
+    )
+
+    assert cache.entries == {}
+
+
+def test_cache_persists_and_reloads(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_path = tmp_path / "cache.json"
+    event = _make_event()
+
+    cache = NegativeEventCache.load(cache_path, rule_hash="hash", now=0)
+    _set_time(monkeypatch, 30.0)
+    cache.record_no_trigger(event, "hash", "no_trigger")
+    cache.flush()
+
+    reloaded = NegativeEventCache.load(cache_path, rule_hash="hash", now=35.0)
+    assert reloaded.should_skip(event, "hash") is True

--- a/utils/negative_cache.py
+++ b/utils/negative_cache.py
@@ -245,4 +245,3 @@ class NegativeEventCache:
             return age <= NEG_CACHE_MAX_AGE_SECONDS
 
         return True
-

--- a/utils/negative_cache.py
+++ b/utils/negative_cache.py
@@ -1,0 +1,248 @@
+"""Negative event cache to avoid reprocessing unchanged events without triggers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+NEG_CACHE_VERSION = 1
+NEG_CACHE_MAX_AGE_DAYS = 30
+NEG_CACHE_MAX_AGE_SECONDS = NEG_CACHE_MAX_AGE_DAYS * 24 * 60 * 60
+
+
+def _parse_iso_timestamp(value: str) -> Optional[datetime]:
+    """Best effort ISO8601 parser supporting ``Z`` suffixes."""
+
+    if not value:
+        return None
+
+    try:
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        return datetime.fromisoformat(value)
+    except ValueError:
+        logger.debug("Unable to parse timestamp '%s' in negative cache", value)
+        return None
+
+
+@dataclass
+class NegativeEventCache:
+    """Caches skip decisions for events without triggers."""
+
+    path: Path
+    entries: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    dirty: bool = False
+    classification_version: str = "v1"
+
+    @classmethod
+    def load(
+        cls,
+        path: Path,
+        *,
+        rule_hash: str,
+        now: Optional[float] = None,
+    ) -> "NegativeEventCache":
+        """Load cache from disk applying retention rules."""
+
+        now = now or time.time()
+        entries: Dict[str, Dict[str, Any]] = {}
+
+        if path.exists():
+            try:
+                raw = json.loads(path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                logger.warning(
+                    "Negative cache at %s contained invalid JSON. Reinitialising.", path
+                )
+                raw = {}
+        else:
+            raw = {}
+
+        if not isinstance(raw, dict):
+            raw = {}
+
+        raw_entries = raw.get("entries") if isinstance(raw.get("entries"), dict) else {}
+
+        for event_id, entry in raw_entries.items():
+            if not isinstance(entry, dict):
+                continue
+            fingerprint = entry.get("fingerprint")
+            if not isinstance(fingerprint, str) or not fingerprint:
+                continue
+
+            updated = entry.get("updated")
+            last_seen = entry.get("last_seen")
+
+            if not cls._is_entry_fresh(updated, last_seen, now):
+                continue
+
+            entries[str(event_id)] = {
+                "fingerprint": fingerprint,
+                "updated": updated if isinstance(updated, str) else None,
+                "rule_hash": entry.get("rule_hash"),
+                "decision": entry.get("decision"),
+                "first_seen": entry.get("first_seen"),
+                "last_seen": last_seen if isinstance(last_seen, (int, float)) else None,
+                "classification_version": entry.get(
+                    "classification_version", "v1"
+                ),
+            }
+
+        cache = cls(path=path, entries=entries, dirty=False)
+        cache._purge_stale(now)  # noqa: SLF001
+        return cache
+
+    def should_skip(self, event: Dict[str, Any], rule_hash: str) -> bool:
+        """Return ``True`` if the event can be skipped based on cached decision."""
+
+        event_id = event.get("id")
+        if not event_id or not isinstance(event_id, str):
+            return False
+
+        fingerprint, _ = self._fingerprint(event)
+        entry = self.entries.get(event_id)
+        if not entry:
+            return False
+
+        if entry.get("rule_hash") != rule_hash:
+            return False
+
+        if entry.get("fingerprint") != fingerprint:
+            return False
+
+        if entry.get("decision") not in {"no_trigger", "skipped_trigger_threshold"}:
+            return False
+
+        last_seen = entry.get("last_seen")
+        now = time.time()
+        if not self._is_entry_fresh(entry.get("updated"), last_seen, now):
+            # Entry is stale; purge and continue processing event.
+            self.forget(event_id)
+            return False
+
+        if not entry.get("updated"):
+            entry["last_seen"] = now
+            self.dirty = True
+
+        return True
+
+    def get_decision(self, event_id: Optional[str]) -> Optional[str]:
+        if not event_id:
+            return None
+        entry = self.entries.get(event_id)
+        if entry:
+            return entry.get("decision")
+        return None
+
+    def record_no_trigger(self, event: Dict[str, Any], rule_hash: str, decision: str) -> None:
+        event_id = event.get("id")
+        if not event_id or not isinstance(event_id, str):
+            return
+
+        fingerprint, updated = self._fingerprint(event)
+        now = time.time()
+
+        entry = self.entries.get(event_id, {})
+        first_seen = entry.get("first_seen", now)
+
+        new_entry = {
+            "fingerprint": fingerprint,
+            "updated": updated,
+            "rule_hash": rule_hash,
+            "decision": decision,
+            "first_seen": first_seen,
+            "last_seen": now if not updated else entry.get("last_seen", now),
+            "classification_version": self.classification_version,
+        }
+
+        if self.entries.get(event_id) != new_entry:
+            self.entries[event_id] = new_entry
+            self.dirty = True
+
+    def forget(self, event_id: Optional[str]) -> None:
+        if not event_id or not isinstance(event_id, str):
+            return
+
+        if event_id in self.entries:
+            del self.entries[event_id]
+            self.dirty = True
+
+    def flush(self) -> None:
+        if not self.dirty:
+            return
+
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            payload = {
+                "version": NEG_CACHE_VERSION,
+                "entries": self.entries,
+            }
+            self.path.write_text(
+                json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+            )
+            self.dirty = False
+        except Exception:
+            logger.warning("Failed to flush negative cache to %s", self.path, exc_info=True)
+
+    def _fingerprint(self, event: Dict[str, Any]) -> tuple[str, Optional[str]]:
+        event_id = str(event.get("id")) if event.get("id") is not None else ""
+        updated = event.get("updated")
+        updated_str: Optional[str]
+        if isinstance(updated, str):
+            updated_str = updated
+        elif isinstance(updated, datetime):
+            updated_str = updated.astimezone(timezone.utc).isoformat()
+        else:
+            updated_str = None
+
+        summary = self._normalise_text(event.get("summary"))
+        description = self._normalise_text(event.get("description"))
+
+        base = f"{event_id}|{updated_str or '-'}|{summary}|{description}"
+        fingerprint = hashlib.sha1(base.encode("utf-8")).hexdigest()
+        return fingerprint, updated_str
+
+    @staticmethod
+    def _normalise_text(value: Any) -> str:
+        if value is None:
+            return ""
+        return str(value).strip().lower()
+
+    def _purge_stale(self, now: Optional[float] = None) -> None:
+        now = now or time.time()
+        removed = [
+            event_id
+            for event_id, entry in list(self.entries.items())
+            if not self._is_entry_fresh(entry.get("updated"), entry.get("last_seen"), now)
+        ]
+        for event_id in removed:
+            del self.entries[event_id]
+            self.dirty = True
+
+    @staticmethod
+    def _is_entry_fresh(
+        updated: Optional[str], last_seen: Optional[float], now: float
+    ) -> bool:
+        if updated:
+            parsed = _parse_iso_timestamp(updated)
+            if parsed is not None:
+                if parsed.tzinfo is None:
+                    parsed = parsed.replace(tzinfo=timezone.utc)
+                age = now - parsed.timestamp()
+                return age <= NEG_CACHE_MAX_AGE_SECONDS
+
+        if last_seen is not None:
+            age = now - float(last_seen)
+            return age <= NEG_CACHE_MAX_AGE_SECONDS
+
+        return True
+


### PR DESCRIPTION
## Summary
- add a reusable `NegativeEventCache` utility with fingerprinting, TTL pruning, and persistence to JSON state
- integrate the cache into `MasterWorkflowAgent` to skip unchanged events, refresh entries on negative decisions, and flush state at run finalisation
- document the negative cache behaviour and cover it with focused unit and workflow tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e00a9a51dc832bbb0c285b06be96a3