### PR TITLE
Align dossier status normalization with backend responses

### DIFF
--- a/agents/human_in_loop_agent.py
+++ b/agents/human_in_loop_agent.py
@@ -378,10 +378,22 @@ class HumanInLoopAgent(BaseHumanAgent):
         Normalizes the response from a backend or simulation to a standard structure.
         """
         if isinstance(response, dict):
+            status = response.get("status")
+            status_decision_map = {
+                "approved": True,
+                "declined": False,
+                "rejected": False,
+                "denied": False,
+                "pending": None,
+            }
+            normalized_status = (
+                str(status).strip().lower() if isinstance(status, str) else None
+            )
+
             if "dossier_required" in response:
                 dossier_required = response.get("dossier_required")
-            elif response.get("status") in {"pending", None}:
-                dossier_required = None
+            elif normalized_status in status_decision_map:
+                dossier_required = status_decision_map[normalized_status]
             else:
                 dossier_required = bool(response)
             details = response.get("details")

--- a/tests/test_master_workflow_agent_hitl.py
+++ b/tests/test_master_workflow_agent_hitl.py
@@ -126,6 +126,16 @@ async def test_soft_trigger_dossier_request_declined() -> None:
     assert backend.requests[0]["info"]["company_name"] == "Example Corp"
 
 
+async def test_soft_trigger_dossier_request_declined_status_only() -> None:
+    backend = DummyBackend({"status": "declined"})
+    agent = _prepare_agent(backend)
+
+    await agent.process_all_events()
+
+    assert agent._send_calls == []
+    assert len(backend.requests) == 1
+
+
 async def test_audit_log_records_dossier_acceptance(tmp_path) -> None:
     backend = DummyBackend(
         {"dossier_required": True, "details": {"note": "Yes, please prepare it."}}
@@ -218,6 +228,16 @@ async def test_soft_trigger_dossier_request_pending(tmp_path) -> None:
             agent.finalize_run_logs()
         settings.run_log_dir = original_run_dir
         settings.workflow_log_dir = original_workflow_dir
+
+
+async def test_soft_trigger_dossier_request_approved_status_only() -> None:
+    backend = DummyBackend({"status": "approved"})
+    agent = _prepare_agent(backend)
+
+    await agent.process_all_events()
+
+    assert len(agent._send_calls) == 1
+    assert len(backend.requests) == 1
 
 
 async def test_audit_log_records_missing_info_flow(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- map known status strings in the HITL agent to dossier decisions before using generic truthiness
- extend regression coverage to ensure status-only "approved" and "declined" responses trigger the correct CRM actions

## Testing
- pytest tests/test_master_workflow_agent_hitl.py

------
https://chatgpt.com/codex/tasks/task_e_68e053d58194832ba4ff813a88a275f9