### PR TITLE
Improve HITL logging to support linting

### DIFF
--- a/agents/human_in_loop_agent.py
+++ b/agents/human_in_loop_agent.py
@@ -117,10 +117,10 @@ class HumanInLoopAgent(BaseHumanAgent):
                 },
             )
 
-        print(
-            "Please provide missing info for event {}: {}".format(
-                masked_event.get("id", "<unknown>"), masked_initial_info
-            )
+        logger.info(
+            "Requesting missing info for event %s: %s",
+            masked_event.get("id", "<unknown>"),
+            masked_initial_info,
         )
         # Notes: Simulate human response for demo purposes.
         extracted["info"]["company_name"] = (


### PR DESCRIPTION
## Summary
- replace the HumanInLoopAgent console print with a structured logger call
- keep the simulated workflow messaging consistent while remaining lint clean

## Testing
- flake8


------
https://chatgpt.com/codex/tasks/task_e_68e05538a550832b96d0e233fa572cd1