### PR TITLE
Add inbox polling agent and unit tests

### DIFF
--- a/polling/__init__.py
+++ b/polling/__init__.py
@@ -1,0 +1,6 @@
+"""Polling helpers and background workers."""
+
+from __future__ import annotations
+
+__all__ = ["inbox_agent"]
+

--- a/polling/__init__.py
+++ b/polling/__init__.py
@@ -3,4 +3,3 @@
 from __future__ import annotations
 
 __all__ = ["inbox_agent"]
-

--- a/polling/inbox_agent.py
+++ b/polling/inbox_agent.py
@@ -176,4 +176,3 @@ class InboxAgent:
 
 
 __all__ = ["InboxAgent", "InboxMessage", "AuditHandler"]
-

--- a/polling/inbox_agent.py
+++ b/polling/inbox_agent.py
@@ -1,0 +1,179 @@
+"""IMAP inbox polling agent used for manual review workflows."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Awaitable, Callable, Mapping, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+AuditHandler = Callable[["InboxMessage", Optional[str]], Awaitable[None]]
+
+
+@dataclass(slots=True)
+class InboxMessage:
+    """Normalized representation of an inbound email message."""
+
+    id: str
+    subject: str
+    sender: str
+    body: str = ""
+    headers: Mapping[str, str] = field(default_factory=dict)
+    received_at: Optional[datetime] = None
+
+    def header(self, name: str) -> Optional[str]:
+        """Return the value for *name* (case-insensitive)."""
+
+        if not self.headers:
+            return None
+        for key, value in self.headers.items():
+            if key.lower() == name.lower():
+                return value
+        return None
+
+
+class InboxAgent:
+    """Polls an IMAP mailbox and forwards relevant messages to handlers."""
+
+    _AUDIT_HEADER_CANDIDATES = (
+        "x-leadmi-audit-id",
+        "x-leadmi-audit",
+        "x-leadmi-auditid",
+    )
+    _AUDIT_SUBJECT_PATTERN = re.compile(
+        r"\baudit(?:\s*id)?\s*[:#-]?\s*([A-Za-z0-9_-]{4,})",
+        re.IGNORECASE,
+    )
+
+    def __init__(
+        self,
+        *,
+        config: Mapping[str, object] | object,
+        poll_interval: float = 60.0,
+    ) -> None:
+        self.config = config
+        self.poll_interval = poll_interval
+        self._handlers: list[AuditHandler] = []
+        self._dedup_lock = asyncio.Lock()
+        self._seen_audit_ids: set[str] = set()
+
+    # ------------------------------------------------------------------
+    # Handler management
+    # ------------------------------------------------------------------
+    def register_handler(self, handler: AuditHandler) -> None:
+        """Register *handler* to receive inbox messages."""
+
+        if not callable(handler):
+            raise TypeError("handler must be awaitable")
+        self._handlers.append(handler)
+
+    # ------------------------------------------------------------------
+    async def _dispatch_message(self, message: InboxMessage) -> bool:
+        """Dispatch *message* to registered handlers if any.
+
+        Returns ``True`` when at least one handler has been invoked and the
+        message wasn't dropped due to deduplication.
+        """
+
+        audit_id = self._detect_audit_id(message)
+
+        async with self._dedup_lock:
+            if audit_id and audit_id in self._seen_audit_ids:
+                logger.debug("Duplicate audit_id detected: %s", audit_id)
+                return False
+            if audit_id:
+                self._seen_audit_ids.add(audit_id)
+
+        if not self._handlers:
+            logger.debug("Dropping inbox message %s; no handlers registered.", message.id)
+            return False
+
+        for handler in list(self._handlers):
+            try:
+                await handler(message, audit_id)
+            except Exception:  # pragma: no cover - surface exception paths
+                logger.exception("Inbox handler %r failed for %s", handler, message.id)
+        return True
+
+    # ------------------------------------------------------------------
+    def _detect_audit_id(self, message: InboxMessage) -> Optional[str]:
+        """Extract an audit identifier from headers or the subject."""
+
+        for candidate in self._AUDIT_HEADER_CANDIDATES:
+            header_value = message.header(candidate)
+            if header_value:
+                return header_value.strip()
+
+        subject = message.subject or ""
+        match = self._AUDIT_SUBJECT_PATTERN.search(subject)
+        if match:
+            return match.group(1).strip()
+        return None
+
+    # ------------------------------------------------------------------
+    async def fetch_new_messages(self) -> Sequence[InboxMessage]:
+        """Return new inbox messages.
+
+        Sub-classes can override this method to integrate with an IMAP client.
+        """
+
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    async def poll_once(self) -> int:
+        """Fetch and dispatch messages once.
+
+        Returns the number of dispatched messages.
+        """
+
+        if not self._is_configured():
+            logger.info("Inbox agent disabled due to incomplete configuration.")
+            return 0
+
+        messages = await self.fetch_new_messages()
+        dispatched = 0
+        for message in messages:
+            handled = await self._dispatch_message(message)
+            if handled:
+                dispatched += 1
+        return dispatched
+
+    # ------------------------------------------------------------------
+    async def start_polling_loop(self) -> None:
+        """Continuously poll the inbox until cancelled."""
+
+        try:
+            while True:
+                await self.poll_once()
+                await asyncio.sleep(self.poll_interval)
+        except asyncio.CancelledError:
+            logger.info("Inbox polling loop cancelled.")
+            raise
+
+    # ------------------------------------------------------------------
+    def _config_value(self, key: str) -> Optional[str]:
+        if isinstance(self.config, Mapping):
+            value = self.config.get(key)
+        else:
+            value = getattr(self.config, key, None)
+        if value in {None, ""}:
+            return None
+        return str(value)
+
+    # ------------------------------------------------------------------
+    def _is_configured(self) -> bool:
+        """Return whether IMAP configuration is available."""
+
+        host = self._config_value("imap_host")
+        user = self._config_value("imap_user")
+        password = self._config_value("imap_password")
+        return bool(host and user and password)
+
+
+__all__ = ["InboxAgent", "InboxMessage", "AuditHandler"]
+

--- a/tests/unit/test_inbox_agent.py
+++ b/tests/unit/test_inbox_agent.py
@@ -194,14 +194,13 @@ async def test_start_polling_loop_handles_cancellation() -> None:
 @pytest.mark.asyncio
 async def test_start_polling_loop_skips_when_disabled() -> None:
     agent = InboxAgent(config={}, poll_interval=0.01)
-    agent.fetch_new_messages = AsyncMock(return_value=[InboxMessage(id="skip", subject="", sender="", headers={})])  # type: ignore[attr-defined]
+    agent.fetch_new_messages = AsyncMock(
+        return_value=[InboxMessage(id="skip", subject="", sender="", headers={})]
+    )  # type: ignore[attr-defined]
 
     task = asyncio.create_task(agent.start_polling_loop())
     await asyncio.sleep(0.05)
     task.cancel()
-
     with pytest.raises(asyncio.CancelledError):
         await task
-
     agent.fetch_new_messages.assert_not_awaited()
-

--- a/tests/unit/test_inbox_agent.py
+++ b/tests/unit/test_inbox_agent.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Optional
+from unittest.mock import AsyncMock
+
+import pytest
+
+from polling.inbox_agent import InboxAgent, InboxMessage
+
+
+def _configured_settings() -> SimpleNamespace:
+    return SimpleNamespace(
+        imap_host="imap.example.com",
+        imap_user="user",
+        imap_password="pass",
+    )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_invokes_handlers_and_detects_header_audit_id() -> None:
+    agent = InboxAgent(config=_configured_settings().__dict__, poll_interval=0)
+    handler_one = AsyncMock()
+    handler_two = AsyncMock()
+    agent.register_handler(handler_one)
+    agent.register_handler(handler_two)
+
+    message = InboxMessage(
+        id="msg-1",
+        subject="Manual review required",
+        sender="operator@example.com",
+        headers={"X-Leadmi-Audit-Id": "audit-123"},
+    )
+
+    handled = await agent._dispatch_message(message)
+
+    assert handled is True
+    handler_one.assert_awaited_once_with(message, "audit-123")
+    handler_two.assert_awaited_once_with(message, "audit-123")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_detects_audit_id_from_subject() -> None:
+    agent = InboxAgent(config=_configured_settings().__dict__, poll_interval=0)
+    handler = AsyncMock()
+    agent.register_handler(handler)
+
+    message = InboxMessage(
+        id="msg-2",
+        subject="Re: Workflow update (Audit ID: subj-456)",
+        sender="operator@example.com",
+        headers={},
+    )
+
+    await agent._dispatch_message(message)
+
+    handler.assert_awaited_once_with(message, "subj-456")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_without_handlers_is_ignored() -> None:
+    agent = InboxAgent(config=_configured_settings().__dict__, poll_interval=0)
+    message = InboxMessage(
+        id="msg-3",
+        subject="No handler",
+        sender="operator@example.com",
+    )
+
+    handled = await agent._dispatch_message(message)
+
+    assert handled is False
+
+
+@pytest.mark.asyncio
+async def test_dispatch_skips_duplicate_audit_ids() -> None:
+    agent = InboxAgent(config=_configured_settings().__dict__, poll_interval=0)
+    handler = AsyncMock()
+    agent.register_handler(handler)
+
+    message = InboxMessage(
+        id="msg-4",
+        subject="Audit update",
+        sender="operator@example.com",
+        headers={"X-Leadmi-Audit-Id": "dup-789"},
+    )
+
+    first = await agent._dispatch_message(message)
+    second = await agent._dispatch_message(message)
+
+    assert first is True
+    assert second is False
+    handler.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_concurrent_duplicates_respect_lock() -> None:
+    agent = InboxAgent(config=_configured_settings().__dict__, poll_interval=0)
+    calls: list[tuple[str, Optional[str]]] = []
+
+    async def handler(msg: InboxMessage, audit_id: Optional[str]) -> None:
+        calls.append((msg.id, audit_id))
+        await asyncio.sleep(0.01)
+
+    agent.register_handler(handler)
+
+    first = InboxMessage(
+        id="msg-5a",
+        subject="Audit check",
+        sender="operator@example.com",
+        headers={"X-Leadmi-Audit-Id": "lock-123"},
+    )
+    second = InboxMessage(
+        id="msg-5b",
+        subject="Audit check",
+        sender="operator@example.com",
+        headers={"X-Leadmi-Audit-Id": "lock-123"},
+    )
+
+    results = await asyncio.gather(
+        agent._dispatch_message(first), agent._dispatch_message(second)
+    )
+
+    assert results.count(True) == 1
+    assert len(calls) == 1
+    assert calls[0] == ("msg-5a", "lock-123") or calls[0] == ("msg-5b", "lock-123")
+
+
+@pytest.mark.asyncio
+async def test_poll_once_processes_messages_and_counts() -> None:
+    agent = InboxAgent(config=_configured_settings().__dict__, poll_interval=0)
+    handler = AsyncMock()
+    agent.register_handler(handler)
+
+    first = InboxMessage(
+        id="poll-1",
+        subject="Audit ID: poll-1",
+        sender="operator@example.com",
+        headers={},
+    )
+    second = InboxMessage(
+        id="poll-2",
+        subject="Audit update",
+        sender="operator@example.com",
+        headers={"X-Leadmi-Audit-Id": "poll-2"},
+    )
+
+    agent.fetch_new_messages = AsyncMock(return_value=[first, second])  # type: ignore[attr-defined]
+
+    processed = await agent.poll_once()
+
+    assert processed == 2
+    awaited = [entry.args for entry in handler.await_args_list]
+    assert (first, "poll-1") in awaited
+    assert (second, "poll-2") in awaited
+
+
+@pytest.mark.asyncio
+async def test_poll_once_respects_configuration_guard() -> None:
+    agent = InboxAgent(config={}, poll_interval=0)
+    agent.fetch_new_messages = AsyncMock(return_value=[])  # type: ignore[attr-defined]
+
+    processed = await agent.poll_once()
+
+    assert processed == 0
+    agent.fetch_new_messages.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_start_polling_loop_handles_cancellation() -> None:
+    agent = InboxAgent(config=_configured_settings().__dict__, poll_interval=0.01)
+    handler = AsyncMock()
+    agent.register_handler(handler)
+
+    message = InboxMessage(
+        id="loop-1",
+        subject="Audit update",
+        sender="operator@example.com",
+        headers={"X-Leadmi-Audit-Id": "loop-1"},
+    )
+
+    agent.fetch_new_messages = AsyncMock(return_value=[message])  # type: ignore[attr-defined]
+
+    task = asyncio.create_task(agent.start_polling_loop())
+    await asyncio.sleep(0.05)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    handler.assert_awaited_once_with(message, "loop-1")
+
+
+@pytest.mark.asyncio
+async def test_start_polling_loop_skips_when_disabled() -> None:
+    agent = InboxAgent(config={}, poll_interval=0.01)
+    agent.fetch_new_messages = AsyncMock(return_value=[InboxMessage(id="skip", subject="", sender="", headers={})])  # type: ignore[attr-defined]
+
+    task = asyncio.create_task(agent.start_polling_loop())
+    await asyncio.sleep(0.05)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    agent.fetch_new_messages.assert_not_awaited()
+


### PR DESCRIPTION
## Summary
- add a reusable inbox polling agent with audit-id detection, deduplication, and cancellation-aware loop handling
- expose the polling helpers package for imports
- introduce unit coverage for dispatch, deduplication, and polling behaviours of the inbox agent

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0dc02a760832bbc57682584a01ace