### PR TITLE
Add inbox reply handling for pending HITL audits

### DIFF
--- a/human_in_the_loop/reply_parsers.py
+++ b/human_in_the_loop/reply_parsers.py
@@ -1,0 +1,47 @@
+"""Light-weight parsers for human-in-the-loop inbox replies."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict
+
+
+def _normalise_key(key: str) -> str:
+    cleaned = re.sub(r"[^a-z0-9]+", "_", key.strip().lower())
+    return cleaned.strip("_")
+
+
+def parse_missing_info_reply(subject: str, body: str) -> Dict[str, Any]:
+    """Return structured data extracted from a missing-info reply."""
+
+    fields: Dict[str, str] = {}
+    for line in body.splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        normalised_key = _normalise_key(key)
+        if not normalised_key:
+            continue
+        cleaned_value = value.strip()
+        if cleaned_value:
+            fields[normalised_key] = cleaned_value
+
+    outcome = "parsed" if fields else "received"
+    return {"fields": fields, "outcome": outcome}
+
+
+def parse_dossier_reply(subject: str, body: str) -> Dict[str, Any]:
+    """Parse organiser dossier decisions from free-form replies."""
+
+    text = f"{subject}\n{body}".lower()
+    decision = None
+    if re.search(r"\b(approve|approved|yes|yep|sure)\b", text):
+        decision = "approved"
+    elif re.search(r"\b(decline|declined|no|nope|reject|rejected)\b", text):
+        decision = "declined"
+
+    outcome = decision or "received"
+    return {"decision": decision, "outcome": outcome}
+
+
+__all__ = ["parse_missing_info_reply", "parse_dossier_reply"]

--- a/polling/inbox_agent.py
+++ b/polling/inbox_agent.py
@@ -144,13 +144,28 @@ class InboxAgent:
         return dispatched
 
     # ------------------------------------------------------------------
-    async def start_polling_loop(self) -> None:
-        """Continuously poll the inbox until cancelled."""
+    async def start_polling_loop(
+        self, *, interval_seconds: Optional[float] = None
+    ) -> None:
+        """Continuously poll the inbox until cancelled.
+
+        Parameters
+        ----------
+        interval_seconds:
+            Optional override for the polling interval. When omitted, the
+            instance's configured ``poll_interval`` is used.
+        """
 
         try:
             while True:
                 await self.poll_once()
-                await asyncio.sleep(self.poll_interval)
+                delay = self.poll_interval
+                if interval_seconds is not None:
+                    try:
+                        delay = max(float(interval_seconds), 0.0)
+                    except (TypeError, ValueError):
+                        delay = self.poll_interval
+                await asyncio.sleep(delay)
         except asyncio.CancelledError:
             logger.info("Inbox polling loop cancelled.")
             raise

--- a/reminders/reminder_escalation.py
+++ b/reminders/reminder_escalation.py
@@ -150,6 +150,19 @@ class ReminderEscalation:
         for task in tasks:
             task.cancel()
 
+    def cancel_for_audit(self, audit_id: str) -> None:
+        """Cancel reminders associated with *audit_id*.
+
+        The current implementation does not track reminders per audit and will
+        therefore cancel all pending tasks. The signature is provided so that
+        callers can uniformly request cancellation without needing to know the
+        underlying storage model. Future enhancements can scope cancellation to
+        specific audit identifiers.
+        """
+
+        _ = audit_id  # Placeholder until reminders are tracked per audit.
+        self.cancel_pending()
+
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------

--- a/utils/audit_log.py
+++ b/utils/audit_log.py
@@ -133,3 +133,17 @@ class AuditLog:
         """Return all audit log entries as a list."""
 
         return list(self.iter_entries())
+
+    def has_response(self, audit_id: str) -> bool:
+        """Return ``True`` when a response entry exists for *audit_id*."""
+
+        if not audit_id:
+            return False
+
+        for entry in self.iter_entries():
+            if (
+                entry.get("audit_id") == audit_id
+                and entry.get("stage") == "response"
+            ):
+                return True
+        return False


### PR DESCRIPTION
## Summary
- integrate the InboxAgent into the orchestrator so pending HITL audits register reply handlers and resume automatically
- extend the master workflow agent to surface pending callbacks and continue after missing info or dossier replies
- add inbox reply parsers plus audit and reminder helpers to dedupe responses

## Testing
- pytest tests/unit/test_inbox_agent.py *(fails: coverage gate enforces 50% project-wide coverage)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e4abebd4832b8b61445fc930e30f