### PR TITLE
Centralize HITL communication settings

### DIFF
--- a/HITL_PIPELINE.md
+++ b/HITL_PIPELINE.md
@@ -1,0 +1,29 @@
+# Human-in-the-Loop Pipeline Configuration
+
+The human-in-the-loop (HITL) pipeline relies on a coordinated set of SMTP and
+IMAP services in addition to scheduling policies for administrator follow-up.
+The following environment variables are read via `config.settings` and provide
+centralised configuration for these components.
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `SMTP_HOST` | Hostname or IP address of the SMTP relay. | _unset_ |
+| `SMTP_PORT` | TCP port used for SMTP connections. | `465` |
+| `SMTP_USERNAME` | Username used to authenticate with the SMTP relay. Falls back to `SMTP_USER` for backwards compatibility. | _unset_ |
+| `SMTP_PASSWORD` | Password used for SMTP authentication. Falls back to `SMTP_PASS`. | _unset_ |
+| `SMTP_SENDER` | Email address that appears in the `From` header. Falls back to `SMTP_FROM` or the SMTP username. | _unset_ |
+| `SMTP_SECURE` | Whether to require an implicit TLS connection when sending email (`1`/`0`, `true`/`false`). | `true` |
+| `IMAP_HOST` | Hostname of the IMAP server that exposes the HITL inbox. | _unset_ |
+| `IMAP_PORT` | TCP port for the IMAP server. | `993` |
+| `IMAP_USERNAME` | Username for IMAP authentication. Falls back to `IMAP_USER`. | _unset_ |
+| `IMAP_PASSWORD` | Password for IMAP authentication. Falls back to `IMAP_PASS`. | _unset_ |
+| `IMAP_MAILBOX` | Name of the mailbox/folder to poll for replies (also accepts `IMAP_FOLDER`). | `INBOX` |
+| `IMAP_USE_SSL` | Whether to use SSL/TLS when connecting to IMAP. Falls back to `IMAP_SSL`. | `true` |
+| `HITL_INBOX_POLL_SECONDS` | Polling interval (in seconds) used by the inbox agent. | `60.0` |
+| `HITL_TIMEZONE` | IANA timezone identifier for scheduling HITL reminders. | `Europe/Berlin` |
+| `HITL_ADMIN_EMAIL` | Optional administrator address that receives HITL escalations. | _unset_ |
+| `HITL_ESCALATION_EMAIL` | Optional distribution list for escalated requests. | _unset_ |
+| `HITL_ADMIN_REMINDER_HOURS` | Comma-separated list of reminder delays (hours) for HITL administrators. | `24.0` |
+
+> **Note:** All services consume these variables via `config.settings`. Production
+code must avoid direct calls to `os.getenv` for the settings above.

--- a/config/config.py
+++ b/config/config.py
@@ -490,55 +490,76 @@ class Settings:
 
         self.smtp_host: Optional[str] = _get_env_var("SMTP_HOST")
         self.smtp_port: int = _get_int_env("SMTP_PORT", 465)
-        self.smtp_user: Optional[str] = _get_env_var("SMTP_USER")
-        self.smtp_password: Optional[str] = _get_env_var("SMTP_PASS")
+        self.smtp_username: Optional[str] = _get_env_var(
+            "SMTP_USERNAME", aliases=("SMTP_USER",)
+        )
+        self.smtp_password: Optional[str] = _get_env_var(
+            "SMTP_PASSWORD", aliases=("SMTP_PASS",)
+        )
         smtp_sender = _get_env_var("SMTP_SENDER") or _get_env_var("SMTP_FROM")
-        if not smtp_sender and self.smtp_user:
-            smtp_sender = self.smtp_user
+        if not smtp_sender and self.smtp_username:
+            smtp_sender = self.smtp_username
         self.smtp_sender: Optional[str] = smtp_sender
         self.smtp_secure: bool = _get_bool_env("SMTP_SECURE", True)
 
+        # Backwards compatibility aliases
+        self.smtp_user = self.smtp_username
+
         self.imap_host: Optional[str] = _get_env_var("IMAP_HOST")
         self.imap_port: int = _get_int_env("IMAP_PORT", 993)
-        self.imap_user: Optional[str] = _get_env_var("IMAP_USER")
-        self.imap_password: Optional[str] = _get_env_var("IMAP_PASS")
+        self.imap_username: Optional[str] = _get_env_var(
+            "IMAP_USERNAME", aliases=("IMAP_USER",)
+        )
+        self.imap_password: Optional[str] = _get_env_var(
+            "IMAP_PASSWORD", aliases=("IMAP_PASS",)
+        )
         self.imap_mailbox: str = (
             _get_env_var("IMAP_MAILBOX")
             or _get_env_var("IMAP_FOLDER")
             or "INBOX"
         )
-        self.imap_ssl: bool = _get_bool_env("IMAP_SSL", True)
+        self.imap_use_ssl: bool = _get_bool_env(
+            "IMAP_USE_SSL", _get_bool_env("IMAP_SSL", True)
+        )
+
+        # Backwards compatibility aliases
+        self.imap_user = self.imap_username
+        self.imap_ssl = self.imap_use_ssl
 
     def _load_hitl_settings(self) -> None:
         """Load human-in-the-loop reminder configuration."""
 
+        self.hitl_inbox_poll_seconds: float = _get_float_env(
+            "HITL_INBOX_POLL_SECONDS", 60.0
+        )
+        self.hitl_timezone: str = _get_env_var("HITL_TIMEZONE") or "Europe/Berlin"
         self.hitl_admin_email: Optional[str] = _get_env_var("HITL_ADMIN_EMAIL")
         self.hitl_escalation_email: Optional[str] = _get_env_var(
             "HITL_ESCALATION_EMAIL"
         )
-        self.hitl_admin_reminder_hours: Tuple[int, ...] = self._parse_hitl_hours(
+        self.hitl_admin_reminder_hours: Tuple[float, ...] = self._parse_hitl_hours(
             _get_env_var("HITL_ADMIN_REMINDER_HOURS"),
-            default=(24, 48),
+            default=(24.0,),
         )
 
     def _parse_hitl_hours(
-        self, value: Optional[str], *, default: Tuple[int, ...]
-    ) -> Tuple[int, ...]:
+        self, value: Optional[str], *, default: Tuple[float, ...]
+    ) -> Tuple[float, ...]:
         """Return reminder hours parsed from a comma-separated string."""
 
         if not value:
             return default
 
-        hours: list[int] = []
+        hours: list[float] = []
         for part in value.split(","):
             chunk = part.strip()
             if not chunk:
                 continue
             try:
-                hours.append(int(chunk))
+                hours.append(float(chunk))
             except ValueError as exc:
                 raise ValueError(
-                    "HITL_ADMIN_REMINDER_HOURS must be a comma-separated list of integers."
+                    "HITL_ADMIN_REMINDER_HOURS must be numeric (comma-separated)."
                 ) from exc
 
         if not hours:

--- a/docs/hitl_pipeline_implementation.md
+++ b/docs/hitl_pipeline_implementation.md
@@ -1,0 +1,31 @@
+# HITL Pipeline Implementation Notes
+
+The HITL workflow polls an IMAP inbox for organiser replies, dispatches them to
+workflow handlers, and escalates outstanding items over email. All runtime
+configuration is provided by `config.settings` and sourced from the environment.
+The variables below describe the communication and policy levers that affect the
+pipeline.
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `SMTP_HOST` | SMTP relay used by `EmailAgent` for outbound notifications. | _unset_ |
+| `SMTP_PORT` | Port for the SMTP relay. | `465` |
+| `SMTP_USERNAME` | Username for SMTP authentication (`SMTP_USER` accepted as an alias). | _unset_ |
+| `SMTP_PASSWORD` | Password for SMTP authentication (`SMTP_PASS` alias supported). | _unset_ |
+| `SMTP_SENDER` | Sender address used in outbound email (falls back to `SMTP_FROM` or the SMTP username). | _unset_ |
+| `SMTP_SECURE` | Enables implicit TLS when sending email. | `true` |
+| `IMAP_HOST` | IMAP server hosting the HITL inbox. | _unset_ |
+| `IMAP_PORT` | Port for the IMAP server. | `993` |
+| `IMAP_USERNAME` | Username for IMAP authentication (`IMAP_USER` alias supported). | _unset_ |
+| `IMAP_PASSWORD` | Password for IMAP authentication (`IMAP_PASS` alias supported). | _unset_ |
+| `IMAP_MAILBOX` | Mailbox or folder name that should be polled (`IMAP_FOLDER` alias supported). | `INBOX` |
+| `IMAP_USE_SSL` | Enables SSL/TLS for IMAP connections (`IMAP_SSL` alias supported). | `true` |
+| `HITL_INBOX_POLL_SECONDS` | Polling cadence (seconds) for `InboxAgent`. | `60.0` |
+| `HITL_TIMEZONE` | Timezone used when scheduling reminder notifications. | `Europe/Berlin` |
+| `HITL_ADMIN_EMAIL` | Primary administrator contact for escalations. | _unset_ |
+| `HITL_ESCALATION_EMAIL` | Distribution list for escalation notifications. | _unset_ |
+| `HITL_ADMIN_REMINDER_HOURS` | Comma-separated schedule (in hours) for HITL admin reminders. | `24.0` |
+
+When extending the pipeline ensure new components read from `config.settings`
+instead of `os.getenv` so that tests and alternative configuration sources remain
+consistent.

--- a/polling/inbox_agent.py
+++ b/polling/inbox_agent.py
@@ -185,7 +185,7 @@ class InboxAgent:
         """Return whether IMAP configuration is available."""
 
         host = self._config_value("imap_host")
-        user = self._config_value("imap_user")
+        user = self._config_value("imap_username") or self._config_value("imap_user")
         password = self._config_value("imap_password")
         return bool(host and user and password)
 

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -153,16 +153,18 @@ def test_email_and_hitl_settings_from_env(monkeypatch):
     env_values = {
         "SMTP_HOST": "smtp.example.com",
         "SMTP_PORT": "2525",
-        "SMTP_USER": "mailer",
-        "SMTP_PASS": "secret",
+        "SMTP_USERNAME": "mailer",
+        "SMTP_PASSWORD": "secret",
         "SMTP_SENDER": "alerts@example.com",
         "SMTP_SECURE": "0",
         "IMAP_HOST": "imap.example.com",
         "IMAP_PORT": "1993",
-        "IMAP_USER": "imap-user",
-        "IMAP_PASS": "imap-pass",
+        "IMAP_USERNAME": "imap-user",
+        "IMAP_PASSWORD": "imap-pass",
         "IMAP_MAILBOX": "support",
-        "IMAP_SSL": "false",
+        "IMAP_USE_SSL": "false",
+        "HITL_INBOX_POLL_SECONDS": "42.5",
+        "HITL_TIMEZONE": "UTC",
         "HITL_ADMIN_EMAIL": "admin@example.com",
         "HITL_ESCALATION_EMAIL": "escalations@example.com",
         "HITL_ADMIN_REMINDER_HOURS": "4, 12, 24",
@@ -174,6 +176,7 @@ def test_email_and_hitl_settings_from_env(monkeypatch):
 
     assert settings.smtp_host == "smtp.example.com"
     assert settings.smtp_port == 2525
+    assert settings.smtp_username == "mailer"
     assert settings.smtp_user == "mailer"
     assert settings.smtp_password == "secret"
     assert settings.smtp_sender == "alerts@example.com"
@@ -181,14 +184,18 @@ def test_email_and_hitl_settings_from_env(monkeypatch):
 
     assert settings.imap_host == "imap.example.com"
     assert settings.imap_port == 1993
+    assert settings.imap_username == "imap-user"
     assert settings.imap_user == "imap-user"
     assert settings.imap_password == "imap-pass"
     assert settings.imap_mailbox == "support"
+    assert settings.imap_use_ssl is False
     assert settings.imap_ssl is False
 
+    assert settings.hitl_inbox_poll_seconds == pytest.approx(42.5)
+    assert settings.hitl_timezone == "UTC"
     assert settings.hitl_admin_email == "admin@example.com"
     assert settings.hitl_escalation_email == "escalations@example.com"
-    assert settings.hitl_admin_reminder_hours == (4, 12, 24)
+    assert settings.hitl_admin_reminder_hours == (4.0, 12.0, 24.0)
 
 
 def test_email_and_hitl_defaults(monkeypatch):
@@ -197,21 +204,24 @@ def test_email_and_hitl_defaults(monkeypatch):
     for key in [
         "SMTP_HOST",
         "SMTP_PORT",
-        "SMTP_USER",
-        "SMTP_PASS",
+        "SMTP_USERNAME",
+        "SMTP_PASSWORD",
         "SMTP_SENDER",
         "SMTP_FROM",
         "SMTP_SECURE",
         "IMAP_HOST",
         "IMAP_PORT",
-        "IMAP_USER",
-        "IMAP_PASS",
+        "IMAP_USERNAME",
+        "IMAP_PASSWORD",
         "IMAP_MAILBOX",
         "IMAP_FOLDER",
         "IMAP_SSL",
+        "IMAP_USE_SSL",
         "HITL_ADMIN_EMAIL",
         "HITL_ESCALATION_EMAIL",
         "HITL_ADMIN_REMINDER_HOURS",
+        "HITL_INBOX_POLL_SECONDS",
+        "HITL_TIMEZONE",
     ]:
         monkeypatch.delenv(key, raising=False)
 
@@ -219,6 +229,7 @@ def test_email_and_hitl_defaults(monkeypatch):
 
     assert settings.smtp_host is None
     assert settings.smtp_port == 465
+    assert settings.smtp_username is None
     assert settings.smtp_user is None
     assert settings.smtp_password is None
     assert settings.smtp_sender is None
@@ -226,14 +237,18 @@ def test_email_and_hitl_defaults(monkeypatch):
 
     assert settings.imap_host is None
     assert settings.imap_port == 993
+    assert settings.imap_username is None
     assert settings.imap_user is None
     assert settings.imap_password is None
     assert settings.imap_mailbox == "INBOX"
+    assert settings.imap_use_ssl is True
     assert settings.imap_ssl is True
 
+    assert settings.hitl_inbox_poll_seconds == pytest.approx(60.0)
+    assert settings.hitl_timezone == "Europe/Berlin"
     assert settings.hitl_admin_email is None
     assert settings.hitl_escalation_email is None
-    assert settings.hitl_admin_reminder_hours == (24, 48)
+    assert settings.hitl_admin_reminder_hours == (24.0,)
 
 
 def test_invalid_hitl_admin_reminder_hours(monkeypatch):


### PR DESCRIPTION
## Summary
- expose SMTP, IMAP, and HITL configuration via `config.settings` with new defaults
- update agents to consume centralized settings instead of reading environment variables directly
- document the HITL environment variables and defaults for operators

## Testing
- PYTEST_ADDOPTS=--no-cov pytest tests/test_config_settings.py

------
https://chatgpt.com/codex/tasks/task_e_68e0f1fe5f54832bb22aefc6688a5d48