### PR TITLE
Normalize inbox replies and enforce audit dedupe

### DIFF
--- a/tests/unit/test_inbox_agent_parsers.py
+++ b/tests/unit/test_inbox_agent_parsers.py
@@ -1,0 +1,45 @@
+from typing import Optional
+
+import pytest
+
+from polling.inbox_agent import (
+    parse_dossier_decision,
+    parse_missing_info_key_values,
+)
+
+
+@pytest.mark.parametrize(
+    "body,expected",
+    [
+        ("\n\nYes, approved", "approved"),
+        ("Ok!", "approved"),
+        ("JA bitte", "approved"),
+        ("Nein, leider nicht", "declined"),
+        ("We must decline this", "declined"),
+        ("", None),
+        ("Maybe later", None),
+    ],
+)
+def test_parse_dossier_decision_variants(body: str, expected: Optional[str]) -> None:
+    assert parse_dossier_decision(body) == expected
+
+
+def test_parse_missing_info_key_values_filters_whitelist() -> None:
+    body = (
+        "Company Name: Acme Corp\n"
+        "Web Domain: acme.com\n"
+        "Phone: 123-456\n"
+        "Company-Domain: example.org"
+    )
+
+    result = parse_missing_info_key_values(body)
+
+    assert result == {"company_name": "Acme Corp", "web_domain": "example.org"}
+
+
+def test_parse_missing_info_key_values_ignores_empty_values() -> None:
+    body = "Company Name:  \nWeb Domain:   "
+
+    result = parse_missing_info_key_values(body)
+
+    assert result == {}


### PR DESCRIPTION
## Summary
- add inbox parsers to interpret dossier decisions and whitelist missing-info key/value pairs
- update workflow orchestrator to use the new parsers, normalize audit responses, and ignore duplicate replies
- add unit tests covering parser behavior and reply deduplication scenarios

## Testing
- `pytest --no-cov tests/unit/test_inbox_agent_parsers.py tests/unit/test_workflow_orchestrator_inbox.py`

------
https://chatgpt.com/codex/tasks/task_e_68e0f96952b4832b9504c14396010d20