### PR TITLE
Remove simulated dossier confirmation fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Automated tests under [`tests/test_pii_masking.py`](tests/test_pii_masking.py) a
 
 ## Human-in-the-loop interactions
 
-Human feedback is requested through the `HumanInLoopAgent`, which can work with a pluggable communication backend (email, Slack, etc.) or fall back to simulated responses. The [`human_in_the_loop/`](human_in_the_loop/README.md) directory documents patterns for custom manual review steps.
+Human feedback is requested through the `HumanInLoopAgent`, which can work with a pluggable communication backend (email, Slack, etc.). Missing-information flows remain deterministic for local demos, but dossier confirmations now require a configured backend—if one is absent the agent raises an explicit error rather than simulating a decision. The [`human_in_the_loop/`](human_in_the_loop/README.md) directory documents patterns for custom manual review steps.
 
 ## Further reading
 

--- a/agents/human_in_loop_agent.py
+++ b/agents/human_in_loop_agent.py
@@ -14,10 +14,16 @@ from utils.pii import mask_pii
 
 logger = logging.getLogger(__name__)
 
+
+class DossierConfirmationBackendUnavailable(RuntimeError):
+    """Raised when dossier confirmation is attempted without a configured backend."""
+
+
 # Notes:
 # HumanInLoopAgent manages human-in-the-loop steps for workflows. It optionally uses a communication backend,
-# such as an EmailAgent or chat integration, to interact with event organizers. If no backend is provided,
-# the agent falls back to a deterministic simulation for demo/testing.
+# such as an EmailAgent or chat integration, to interact with event organizers. In production environments a
+# backend is required for dossier confirmations; only missing-info flows fall back to deterministic behaviour
+# for demos and tests.
 
 
 @register_agent(BaseHumanAgent, "human_in_loop", "default", is_default=True)
@@ -43,8 +49,9 @@ class HumanInLoopAgent(BaseHumanAgent):
         communication_backend:
             A communication client (e.g. EmailAgent, Slack integration) responsible for
             contacting the event organizer. It should provide either a 'request_confirmation'
-            or 'send_confirmation_request' method. If not supplied, the agent uses a
-            deterministic simulation (useful for demos and tests).
+            or 'send_confirmation_request' method. When omitted, missing-info flows use a
+            deterministic simulation for demos/tests, but dossier confirmations will raise
+            an explicit error so production deployments cannot silently auto-approve.
         """
         self.communication_backend = communication_backend
         self.audit_log: Optional[AuditLog] = None
@@ -177,6 +184,11 @@ class HumanInLoopAgent(BaseHumanAgent):
                     ...context info...
                 }
             }
+
+        Raises
+        ------
+        DossierConfirmationBackendUnavailable
+            If no communication backend is configured for dossier confirmation requests.
         """
         contact = self._extract_organizer_contact(event)
         masked_event = self._mask_for_message(event)
@@ -187,6 +199,14 @@ class HumanInLoopAgent(BaseHumanAgent):
 
         backend_response: Optional[Any] = None
         handler = self._resolve_backend_handler()
+        if handler is None:
+            error_message = (
+                "No communication backend configured for dossier confirmation; "
+                "expected a 'request_confirmation' or 'send_confirmation_request' method."
+            )
+            logger.error(error_message)
+            raise DossierConfirmationBackendUnavailable(error_message)
+
         responder_label = self._backend_label(handler)
         masked_contact = self._mask_for_message(contact)
         contact_label = self._format_contact_label(masked_contact)
@@ -204,22 +224,16 @@ class HumanInLoopAgent(BaseHumanAgent):
                     "contact": masked_contact,
                 },
             )
-        if handler:
-            logger.debug("Sending dossier confirmation request via backend %s", handler)
-            backend_response = self._call_backend_handler(
-                handler,
-                contact=contact,
-                subject=subject,
-                message=message,
-                event=event,
-                info=info,
-                payload=payload,
-            )
-        else:
-            logger.debug(
-                "No communication backend configured; using simulated response."
-            )
-            backend_response = self._simulate_confirmation(contact, payload)
+        logger.debug("Sending dossier confirmation request via backend %s", handler)
+        backend_response = self._call_backend_handler(
+            handler,
+            contact=contact,
+            subject=subject,
+            message=message,
+            event=event,
+            info=info,
+            payload=payload,
+        )
 
         normalized = self._normalize_response(backend_response)
         details = normalized.get("details", {})
@@ -274,7 +288,7 @@ class HumanInLoopAgent(BaseHumanAgent):
 
     def _backend_label(self, handler: Optional[Any]) -> str:
         if handler is None:
-            return "simulation"
+            return "unconfigured_backend"
         bound = getattr(handler, "__self__", None)
         if bound is not None:
             return bound.__class__.__name__
@@ -353,25 +367,6 @@ class HumanInLoopAgent(BaseHumanAgent):
         lines.append("")
         lines.append("Should we prepare a dossier for this event? Reply yes or no.")
         return "\n".join(lines)
-
-    def _simulate_confirmation(
-        self, contact: Dict[str, Any], payload: Dict[str, Any]
-    ) -> Dict[str, Any]:
-        """
-        Simulates dossier confirmation (used for tests or when no backend is available).
-        """
-        logger.info(
-            "Simulating dossier confirmation for organiser %s",
-            self._mask_for_message(contact).get("email"),
-        )
-        return {
-            "dossier_required": True,
-            "details": {
-                "simulation": True,
-                "reason": "Default simulated approval",
-                "contact": contact,
-            },
-        }
 
     def _normalize_response(self, response: Any) -> Dict[str, Any]:
         """

--- a/human_in_the_loop/README.md
+++ b/human_in_the_loop/README.md
@@ -17,5 +17,6 @@ these concepts with additional orchestration logic and pluggable communication b
 * Integrate with messaging platforms (email, Slack, ticketing systems) by injecting
   backend clients that expose clear confirmation methods.
 * Record human responses in the logging layer for auditability.
-* Keep HITL flows deterministic in tests by providing mocked backends or simulated
-  responses.
+* Keep HITL flows deterministic in tests by providing mocked backends. Dossier
+  confirmation paths no longer simulate approvals—tests should inject explicit
+  responses via the backend interface.

--- a/tests/test_human_in_loop_reminders.py
+++ b/tests/test_human_in_loop_reminders.py
@@ -92,7 +92,7 @@ def test_dossier_confirmation_without_backend_raises() -> None:
     agent = HumanInLoopAgent(communication_backend=None)
     event = {
         "id": "evt-2",
-        "summary": "No backend", 
+        "summary": "No backend",
         "organizer": {"email": "organizer@example.com"},
     }
     info = {"company_name": "Example Corp"}

--- a/tests/test_human_in_loop_reminders.py
+++ b/tests/test_human_in_loop_reminders.py
@@ -4,7 +4,10 @@ from typing import Any, Dict
 
 import pytest
 
-from agents.human_in_loop_agent import HumanInLoopAgent
+from agents.human_in_loop_agent import (
+    DossierConfirmationBackendUnavailable,
+    HumanInLoopAgent,
+)
 from logs.workflow_log_manager import WorkflowLogManager
 
 
@@ -83,3 +86,16 @@ async def test_pending_confirmation_triggers_reminders(tmp_path) -> None:
     assert "hitl_dossier_reminder_scheduled" in workflow_text
 
     agent.shutdown()
+
+
+def test_dossier_confirmation_without_backend_raises() -> None:
+    agent = HumanInLoopAgent(communication_backend=None)
+    event = {
+        "id": "evt-2",
+        "summary": "No backend", 
+        "organizer": {"email": "organizer@example.com"},
+    }
+    info = {"company_name": "Example Corp"}
+
+    with pytest.raises(DossierConfirmationBackendUnavailable):
+        agent.request_dossier_confirmation(event, info)


### PR DESCRIPTION
## Summary
- raise a dedicated error when dossier confirmation is attempted without a configured communication backend
- surface skipped dossier confirmations in the master workflow instead of simulating approvals and update documentation accordingly
- add regression tests that cover the missing-backend path for both the HITL agent and the master workflow

## Testing
- pytest tests/test_human_in_loop_reminders.py tests/test_master_workflow_agent_hitl.py *(fails repository-wide coverage threshold requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68e1054f87dc832b96b6b8c8b5072bf9