### PR TITLE
Set default calendar window and expand tests

### DIFF
--- a/integration/google_calendar_integration.py
+++ b/integration/google_calendar_integration.py
@@ -196,8 +196,12 @@ class GoogleCalendarIntegration:
     ) -> List[dict]:
         await self._ensure_access_token_async()
 
+        now_utc = datetime.now(timezone.utc)
         if time_min is None:
-            time_min = datetime.now(timezone.utc)
+            time_min = now_utc - timedelta(days=self.cal_lookback_days)
+
+        if time_max is None:
+            time_max = now_utc + timedelta(days=self.cal_lookahead_days)
 
         return await self._list_events_async(
             start_time=time_min,


### PR DESCRIPTION
## Summary
- default Google Calendar event listings to use the configured lookback/lookahead window when explicit bounds are missing
- ensure computed defaults and explicit overrides are passed through to the low-level request helper
- extend unit tests to validate generated request parameters and default/explicit behaviour

## Testing
- pytest --no-cov tests/test_google_calendar_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68e19ad22be4832b8268893c1de1ad19