### PR TITLE
Add processed event cache to skip already dispatched events

### DIFF
--- a/tests/test_master_workflow_agent_negative_cache.py
+++ b/tests/test_master_workflow_agent_negative_cache.py
@@ -33,6 +33,14 @@ class StubExtractionAgent:
         return {"info": {}, "is_complete": False}
 
 
+class StubCrmAgent:
+    def __init__(self) -> None:
+        self.sent: List[Dict[str, Any]] = []
+
+    async def send(self, event: Dict[str, Any], info: Dict[str, Any]) -> None:
+        self.sent.append({"event": dict(event), "info": dict(info)})
+
+
 async def _run_agent(
     events: Iterable[Dict[str, Any]],
     *,
@@ -83,3 +91,66 @@ async def test_negative_cache_skips_and_reprocesses(
 
     third_run = await _run_agent([updated_event], trigger_result=trigger_result)
     assert third_run[0]["status"] == "no_trigger"
+
+
+async def test_processed_event_cache_skips_repeat_dispatch(tmp_path, monkeypatch):
+    run_dir = tmp_path / "runs"
+    workflow_dir = tmp_path / "workflow"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    workflow_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(settings, "run_log_dir", run_dir)
+    monkeypatch.setattr(settings, "workflow_log_dir", workflow_dir)
+
+    event = {
+        "id": "evt-hard-1",
+        "updated": "2024-05-01T10:00:00Z",
+        "summary": "Urgent expansion",
+        "description": "Customer expanding operations.",
+    }
+    trigger_result = {"trigger": True, "type": "hard", "confidence": 0.99}
+    extraction_result = {
+        "info": {"company_name": "Acme Corp", "company_domain": "acme.com"},
+        "is_complete": True,
+        "confidence": 0.95,
+    }
+
+    async def _run_positive_agent(crm_agent: StubCrmAgent) -> List[Dict[str, Any]]:
+        agent = MasterWorkflowAgent(
+            event_agent=StubEventAgent([event]),
+            trigger_agent=StubTriggerAgent(trigger_result),
+            extraction_agent=StubExtractionAgent(),
+            crm_agent=crm_agent,
+        )
+
+        async def fake_internal(*args: Any, **kwargs: Any) -> Dict[str, Any]:
+            return {"status": "REPORT_REQUIRED"}
+
+        async def fake_precrm(*args: Any, **kwargs: Any) -> None:
+            return None
+
+        async def fake_extract(_event: Dict[str, Any]) -> Dict[str, Any]:
+            return dict(extraction_result)
+
+        agent._run_internal_research = fake_internal  # type: ignore[assignment]
+        agent._execute_precrm_research = fake_precrm  # type: ignore[assignment]
+        agent.extraction_agent.extract = fake_extract  # type: ignore[assignment]
+
+        run_id = generate_run_id()
+        current_run_id_var.set(run_id)
+        agent.attach_run(run_id, agent.workflow_log_manager)
+
+        try:
+            return await agent.process_all_events()
+        finally:
+            agent.finalize_run_logs()
+
+    first_crm_agent = StubCrmAgent()
+    first_run = await _run_positive_agent(first_crm_agent)
+    assert first_run[0]["status"] == "dispatched_to_crm"
+    assert len(first_crm_agent.sent) == 1
+
+    second_crm_agent = StubCrmAgent()
+    second_run = await _run_positive_agent(second_crm_agent)
+    assert second_run[0]["status"] == "skipped_processed_event"
+    assert second_crm_agent.sent == []

--- a/utils/processed_event_cache.py
+++ b/utils/processed_event_cache.py
@@ -1,0 +1,144 @@
+"""Persistent tracker for events that have completed processing."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ProcessedEventCache:
+    """Stores fingerprints of events that have been dispatched."""
+
+    path: Path
+    entries: Dict[str, Dict[str, Optional[str]]] = field(default_factory=dict)
+    dirty: bool = False
+
+    @classmethod
+    def load(cls, path: Path) -> "ProcessedEventCache":
+        """Load cache entries from *path* if it exists."""
+
+        entries: Dict[str, Dict[str, Optional[str]]] = {}
+        if path.exists():
+            try:
+                raw = json.loads(path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                logger.warning(
+                    "Processed event cache at %s contained invalid JSON. Reinitialising.",
+                    path,
+                )
+                raw = {}
+        else:
+            raw = {}
+
+        if not isinstance(raw, dict):
+            raw = {}
+
+        raw_entries = raw.get("entries") if isinstance(raw.get("entries"), dict) else raw
+        if isinstance(raw_entries, dict):
+            for event_id, entry in raw_entries.items():
+                if not isinstance(entry, dict):
+                    continue
+                fingerprint = entry.get("fingerprint")
+                if not isinstance(fingerprint, str) or not fingerprint:
+                    continue
+                updated = entry.get("updated")
+                entries[str(event_id)] = {
+                    "fingerprint": fingerprint,
+                    "updated": updated if isinstance(updated, str) else None,
+                }
+
+        return cls(path=path, entries=entries, dirty=False)
+
+    def is_processed(self, event: Dict[str, Any]) -> bool:
+        """Return ``True`` if *event* matches a processed entry."""
+
+        event_id = event.get("id")
+        if not isinstance(event_id, str) or not event_id:
+            return False
+
+        fingerprint, _ = self._fingerprint(event)
+        entry = self.entries.get(event_id)
+        if not entry:
+            return False
+
+        if entry.get("fingerprint") == fingerprint:
+            return bool(entry.get("updated"))
+
+        # Payload changed since last dispatch; forget cached fingerprint so the
+        # event will be processed again.
+        self.forget(event_id)
+        return False
+
+    def mark_processed(self, event: Dict[str, Any]) -> None:
+        """Persist the fingerprint for a successfully dispatched *event*."""
+
+        event_id = event.get("id")
+        if not isinstance(event_id, str) or not event_id:
+            return
+
+        fingerprint, updated = self._fingerprint(event)
+        if not updated:
+            # Without an ``updated`` timestamp we cannot reliably deduplicate.
+            self.forget(event_id)
+            return
+
+        entry = {"fingerprint": fingerprint, "updated": updated}
+        if self.entries.get(event_id) != entry:
+            self.entries[event_id] = entry
+            self.dirty = True
+
+    def forget(self, event_id: Optional[str]) -> None:
+        if not isinstance(event_id, str) or not event_id:
+            return
+
+        if event_id in self.entries:
+            del self.entries[event_id]
+            self.dirty = True
+
+    def flush(self) -> None:
+        if not self.dirty:
+            return
+
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            payload = {"entries": self.entries}
+            self.path.write_text(
+                json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+            )
+            self.dirty = False
+        except Exception:
+            logger.warning(
+                "Failed to flush processed event cache to %s", self.path, exc_info=True
+            )
+
+    def _fingerprint(self, event: Dict[str, Any]) -> tuple[str, Optional[str]]:
+        event_id = str(event.get("id")) if event.get("id") is not None else ""
+        updated = event.get("updated")
+        updated_str: Optional[str]
+        if isinstance(updated, str):
+            updated_str = updated
+        elif isinstance(updated, datetime):
+            updated_str = updated.astimezone(timezone.utc).isoformat()
+        else:
+            updated_str = None
+
+        summary = self._normalise_text(event.get("summary"))
+        description = self._normalise_text(event.get("description"))
+
+        base = f"{event_id}|{updated_str or '-'}|{summary}|{description}"
+        fingerprint = hashlib.sha1(base.encode("utf-8")).hexdigest()
+        return fingerprint, updated_str
+
+    @staticmethod
+    def _normalise_text(value: Any) -> str:
+        if value is None:
+            return ""
+        return str(value).strip().lower()


### PR DESCRIPTION
## Summary
- add a persistent `ProcessedEventCache` for remembering dispatched events by id and fingerprint
- integrate the processed-event tracker into `MasterWorkflowAgent` so already dispatched events are skipped and flushed
- expand the negative cache test suite with a regression that ensures duplicate hard-trigger events are skipped after one dispatch

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e19f397244832b8f5645306ba79718