### PR TITLE
Persist level 1 similar company artifacts per run

### DIFF
--- a/tests/integration/test_workflow_orchestrator_integration.py
+++ b/tests/integration/test_workflow_orchestrator_integration.py
@@ -265,7 +265,10 @@ async def test_orchestrator_records_research_artifacts_and_email_details(
                         "run_id": similar_snapshot["run_id"],
                         "event_id": similar_snapshot["event_id"],
                         "results": similar_snapshot["results"],
-                        "artifact_path": "stub/similar_companies_level1.json",
+                        "artifact_path": (
+                            "stub/similar_companies_level1/"
+                            "run-123/similar_companies_level1_evt-456.json"
+                        ),
                     },
                 },
             },
@@ -321,6 +324,9 @@ async def test_orchestrator_records_research_artifacts_and_email_details(
     similar_payload = entry["research"]["similar_companies_level1"]["payload"]
     assert len(similar_payload["results"]) == 2
     assert similar_payload["results"][0]["id"] == "1"
+    artifact_path = similar_payload["artifact_path"]
+    assert artifact_path.endswith("similar_companies_level1_evt-456.json")
+    assert "/run-123/" in artifact_path.replace("\\", "/")
 
     final_email = master_agent.results[0]["final_email"]
     assert final_email["attachments"] == ["stub/dossier.pdf"]


### PR DESCRIPTION
## Summary
- store similar_companies_level1 artefacts beneath run-specific directories and return their paths in the agent payload
- generate unique filenames for each run/event combination to prevent overwriting
- update the unit/integration coverage to assert the new artefact locations and ensure previous executions remain intact

## Testing
- pytest --no-cov tests/unit/test_int_lvl_1_agent.py
- pytest --no-cov tests/integration/test_workflow_orchestrator_integration.py::test_orchestrator_records_research_artifacts_and_email_details

------
https://chatgpt.com/codex/tasks/task_e_68e1a5dd06ac832b97b1109bd55f9921