### PR TITLE
Fix OTEL collector config and document local setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,16 +196,16 @@ Traces are exported with spans for the overall run (`workflow.run`) and each sub
 
 ### Deployment guidance
 
-Telemetry exporters default to the OTLP/gRPC protocol and honour the standard OpenTelemetry environment variables. The lightweight bootstrap in `main.py` only enables telemetry when one of `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, or `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` is defined. To stream metrics and traces to a local collector:
+Telemetry exporters default to the OTLP/gRPC protocol and honour the standard OpenTelemetry environment variables. The lightweight bootstrap in `main.py` only enables telemetry when one of `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, or `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` is defined. To stream traces to the local OpenTelemetry Collector that is bundled with this repository, start the docker-compose stack (the collector reads the config in [`observability/otel/collector-config.yml`](observability/otel/collector-config.yml)):
 
 ```bash
-docker run --rm -p 4317:4317 -p 4318:4318 otel/opentelemetry-collector:latest
+docker compose up otel-collector
 ```
 
-Then start the orchestrator with the OTLP endpoint configured (the collector listens on `4317` by default):
+The application container already exports traces to the Collector via HTTP (`/v1/traces`) using the default port `4318`. When running the orchestrator or other local scripts outside of Docker, point `OTEL_EXPORTER_OTLP_ENDPOINT` at the collector service:
 
 ```bash
-export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
 python -m agents.workflow_orchestrator
 ```
 

--- a/observability/otel/collector-config.yml
+++ b/observability/otel/collector-config.yml
@@ -1,40 +1,19 @@
-version: "3.9"
+receivers:
+  otlp:
+    protocols:
+      http:
+      grpc:
 
-services:
-  leadmi:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    container_name: leadmi
-    depends_on:
-      - otel-collector
-    environment:
-      - APP_ENV=local  # Notes: same env var for app & telemetry
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
-    ports:
-      - "8080:8080"
-    volumes:
-      - ./log_storage:/app/log_storage
-    restart: always
+processors:
+  batch: {}
 
-  otel-collector:
-    image: otel/opentelemetry-collector:0.136.0
-    container_name: otel-collector
-    environment:
-      - APP_ENV=local  # Notes: used in otel-config.yaml -> deployment.environment
-    command: ["--config", "/etc/otel/config.yaml"]
-    volumes:
-      - ./otel-config.yaml:/etc/otel/config.yaml:ro
-    ports:
-      - "4317:4317"  # gRPC OTLP
-      - "4318:4318"  # HTTP OTLP
-      - "13133:13133" # Health endpoint
-    healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:13133/healthz"]
-      interval: 15s
-      retries: 3
-    restart: unless-stopped
+exporters:
+  logging:
+    loglevel: info
 
-networks:
-  default:
-    name: leadmi-network
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging]


### PR DESCRIPTION
## Summary
- replace the placeholder collector configuration with a real OTLP receiver that batches and logs traces
- document how to run the bundled collector and note the OTLP endpoint used by the application

## Testing
- docker compose up --build *(fails: docker is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e24b18b2ec832b9af53d0c28a9477c