### PR TITLE
Switch OTEL collector exporter to debug output

### DIFF
--- a/observability/otel/collector-config.yml
+++ b/observability/otel/collector-config.yml
@@ -8,12 +8,12 @@ processors:
   batch: {}
 
 exporters:
-  logging:
-    loglevel: info
+  debug:
+    verbosity: detailed
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]


### PR DESCRIPTION
## Summary
- replace the OpenTelemetry Collector logging exporter with the debug exporter configuration
- update the traces pipeline to point at the new debug exporter

## Testing
- docker compose up otel-collector -d *(fails: docker command not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e25ade3644832baf6a2f285226c141