### PR TITLE
Configure OTLP receiver endpoints

### DIFF
--- a/observability/otel/collector-config.yml
+++ b/observability/otel/collector-config.yml
@@ -2,7 +2,9 @@ receivers:
   otlp:
     protocols:
       http:
+        endpoint: 0.0.0.0:4318
       grpc:
+        endpoint: 0.0.0.0:4317
 
 processors:
   batch: {}


### PR DESCRIPTION
## Summary
- configure the OpenTelemetry Collector's OTLP receiver to listen explicitly on both HTTP and gRPC endpoints

## Testing
- not run (environment lacks docker)

------
https://chatgpt.com/codex/tasks/task_e_68e260788ef0832b9721990625953804