### PR TITLE
Prevent Level 1 agent from returning the target company

### DIFF
--- a/agents/int_lvl_1_agent.py
+++ b/agents/int_lvl_1_agent.py
@@ -175,6 +175,15 @@ class IntLvl1SimilarCompaniesAgent(BaseResearchAgent):
             payload.get("company_name") or payload.get("name") or ""
         )
         context["company_name_normalised"] = normalize_text(context["company_name"])
+
+        domain = (
+            payload.get("domain")
+            or payload.get("company_domain")
+            or payload.get("website")
+            or payload.get("company_website")
+        )
+        context["domain"] = domain or ""
+        context["domain_normalised"] = normalize_text(domain)
         for criteria_field in self._match_config.fields:
             raw_value = payload.get(criteria_field) or payload.get(
                 f"company_{criteria_field}"
@@ -232,6 +241,18 @@ class IntLvl1SimilarCompaniesAgent(BaseResearchAgent):
         if not normalised_name:
             return None
 
+        target_name = target_context.get("company_name_normalised", "")
+        candidate_domain_value = properties.get("domain") or properties.get("website")
+        candidate_domain_normalised = normalize_text(candidate_domain_value)
+        target_domain = target_context.get("domain_normalised", "")
+
+        if target_name and normalised_name == target_name:
+            if target_domain and candidate_domain_normalised:
+                if candidate_domain_normalised == target_domain:
+                    return None
+            else:
+                return None
+
         match_score, matched_fields = self._calculate_score(
             properties, target_context, normalised_name
         )
@@ -241,7 +262,7 @@ class IntLvl1SimilarCompaniesAgent(BaseResearchAgent):
             normalize_text(candidate.get("id")),
         )
 
-        domain = properties.get("domain") or properties.get("website") or ""
+        domain = candidate_domain_value or ""
 
         return {
             "id": candidate.get("id"),

--- a/tests/integration/test_workflow_orchestrator_integration.py
+++ b/tests/integration/test_workflow_orchestrator_integration.py
@@ -323,7 +323,7 @@ async def test_orchestrator_records_research_artifacts_and_email_details(
 
     similar_payload = entry["research"]["similar_companies_level1"]["payload"]
     assert len(similar_payload["results"]) == 2
-    assert similar_payload["results"][0]["id"] == "1"
+    assert [result["id"] for result in similar_payload["results"]] == ["2", "3"]
     artifact_path = similar_payload["artifact_path"]
     assert artifact_path.endswith("similar_companies_level1_evt-456.json")
     assert "/run-123/" in artifact_path.replace("\\", "/")

--- a/tests/unit/snapshots/similar_companies_level1.json
+++ b/tests/unit/snapshots/similar_companies_level1.json
@@ -5,25 +5,6 @@
   "generated_at": "01.01.2024 13:00 CET",
   "results": [
     {
-      "id": "1",
-      "name": "Example Analytics",
-      "domain": "example.com",
-      "score": 10.0,
-      "matching_fields": [
-        "description",
-        "name",
-        "product",
-        "segment"
-      ],
-      "properties": {
-        "name": "Example Analytics",
-        "segment": "Enterprise",
-        "product": "Insight Platform",
-        "description": "Predictive analytics tools for marketing departments.",
-        "domain": "example.com"
-      }
-    },
-    {
       "id": "2",
       "name": "Example Insights",
       "domain": "insights.example",
@@ -38,6 +19,22 @@
         "product": "Insight Platform",
         "description": "Analytics for marketing and sales teams.",
         "domain": "insights.example"
+      }
+    },
+    {
+      "id": "3",
+      "name": "Example Services",
+      "domain": "services.example",
+      "score": 3.0,
+      "matching_fields": [
+        "segment"
+      ],
+      "properties": {
+        "name": "Example Services",
+        "segment": "Enterprise",
+        "product": "Support Suite",
+        "description": "Customer success tooling.",
+        "domain": "services.example"
       }
     }
   ]


### PR DESCRIPTION
## Summary
- skip HubSpot candidates whose normalised name (and matching domain when available) corresponds to the target company
- capture the target domain in the level 1 agent context to support the self-match filter
- refresh the level 1 similar companies unit tests and snapshot to expect the filtered results and cover the new behaviour

## Testing
- pytest --no-cov tests/unit/test_int_lvl_1_agent.py


------
https://chatgpt.com/codex/tasks/task_e_68e2729eac38832bb0f320b8f359800e