### PR TITLE
Enforce event text validation when resolving web domains

### DIFF
--- a/tests/test_master_workflow_agent_hard_trigger.py
+++ b/tests/test_master_workflow_agent_hard_trigger.py
@@ -38,7 +38,10 @@ class DummyExtractionAgent:
 async def test_hard_trigger_with_complete_info_dispatches_without_unhandled_state() -> (
     None
 ):
-    event = {"id": "event-001", "summary": "Hard trigger meeting"}
+    event = {
+        "id": "event-001",
+        "summary": "Hard trigger meeting about example.ai",
+    }
     info = {"company_name": "Example Corp", "company_domain": "example.ai"}
 
     agent = MasterWorkflowAgent(

--- a/tests/test_master_workflow_agent_hitl.py
+++ b/tests/test_master_workflow_agent_hitl.py
@@ -66,7 +66,7 @@ class DummyExtractionAgent:
 def _prepare_agent(backend: Optional[DummyBackend]) -> MasterWorkflowAgent:
     event = {
         "id": "event-123",
-        "summary": "Soft trigger meeting",
+        "summary": "Soft trigger meeting for example.ai",
         "organizer": {"email": "organizer@example.com", "displayName": "Org"},
     }
     info = {"company_name": "Example Corp", "web_domain": "example.ai"}

--- a/tests/test_master_workflow_agent_negative_cache.py
+++ b/tests/test_master_workflow_agent_negative_cache.py
@@ -105,7 +105,7 @@ async def test_processed_event_cache_skips_repeat_dispatch(tmp_path, monkeypatch
     event = {
         "id": "evt-hard-1",
         "updated": "2024-05-01T10:00:00Z",
-        "summary": "Urgent expansion",
+        "summary": "Urgent expansion for acme.com",
         "description": "Customer expanding operations.",
     }
     trigger_result = {"trigger": True, "type": "hard", "confidence": 0.99}

--- a/tests/test_observability_smoke.py
+++ b/tests/test_observability_smoke.py
@@ -184,7 +184,7 @@ async def test_observability_records_metrics_and_traces(
 
         event = {
             "id": "evt-1",
-            "summary": "Soft trigger event",
+            "summary": "Soft trigger event about example.ai",
             "organizer": {"email": "user@example.com"},
         }
         extraction_payload = {

--- a/tests/unit/test_hitl_pipeline_e2e.py
+++ b/tests/unit/test_hitl_pipeline_e2e.py
@@ -118,8 +118,13 @@ def _build_orchestrator(
 
 
 def _pending_context(info: Dict[str, Any]) -> Dict[str, Any]:
+    domain_hint = info.get("company_domain") or "acme.com"
     return {
-        "event": {"id": "evt-123", "creator": "organizer@example.com"},
+        "event": {
+            "id": "evt-123",
+            "creator": "organizer@example.com",
+            "summary": f"Follow-up regarding {domain_hint}",
+        },
         "info": info,
         "event_id": "evt-123",
     }

--- a/tests/unit/test_master_workflow_agent_followups.py
+++ b/tests/unit/test_master_workflow_agent_followups.py
@@ -97,7 +97,10 @@ async def test_missing_info_continuation_dispatches_when_complete(monkeypatch: p
     monkeypatch.setattr(agent, "_record_missing_info_completion", lambda event_id: None)
 
     context = {
-        "event": {"id": "evt-1"},
+        "event": {
+            "id": "evt-1",
+            "summary": "Event discussion about acme.com",
+        },
         "info": {"company_name": "Acme"},
         "event_id": "evt-1",
     }
@@ -130,7 +133,10 @@ async def test_missing_info_continuation_registers_pending(monkeypatch: pytest.M
     monkeypatch.setattr(agent, "_process_crm_dispatch", lambda *args, **kwargs: None)
 
     context = {
-        "event": {"id": "evt-2"},
+        "event": {
+            "id": "evt-2",
+            "summary": "Event discussion about acme.com",
+        },
         "info": {"company_name": ""},
         "event_id": "evt-2",
     }
@@ -175,7 +181,10 @@ async def test_missing_info_pending_handler_failure_is_logged(
     monkeypatch.setattr(agent, "_process_crm_dispatch", lambda *args, **kwargs: None)
 
     context = {
-        "event": {"id": "evt-3"},
+        "event": {
+            "id": "evt-3",
+            "summary": "Event discussion about acme.com",
+        },
         "info": {"company_name": ""},
         "event_id": "evt-3",
     }
@@ -199,7 +208,10 @@ async def test_missing_info_continuation_marks_incomplete(monkeypatch: pytest.Mo
     monkeypatch.setattr(agent, "_process_crm_dispatch", lambda *args, **kwargs: None)
 
     context = {
-        "event": {"id": "evt-3"},
+        "event": {
+            "id": "evt-3",
+            "summary": "Event discussion about acme.com",
+        },
         "info": {"company_name": ""},
         "event_id": "evt-3",
     }
@@ -235,7 +247,10 @@ async def test_missing_info_pending_handler_errors_are_ignored(
     monkeypatch.setattr(agent, "_process_crm_dispatch", lambda *args, **kwargs: None)
 
     context = {
-        "event": {"id": "evt-err"},
+        "event": {
+            "id": "evt-err",
+            "summary": "Event discussion about acme.com",
+        },
         "info": {"company_name": ""},
         "event_id": "evt-err",
     }
@@ -283,7 +298,10 @@ async def test_missing_info_follow_up_completes(monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setattr(agent, "_process_crm_dispatch", _fake_dispatch)
 
     context = {
-        "event": {"id": "evt-6"},
+        "event": {
+            "id": "evt-6",
+            "summary": "Event discussion about acme.com",
+        },
         "info": {"company_name": ""},
         "event_id": "evt-6",
     }
@@ -301,7 +319,14 @@ async def test_dossier_continuation_decline_short_circuits(monkeypatch: pytest.M
     agent = _build_agent(human)
     monkeypatch.setattr(agent, "_process_crm_dispatch", lambda *args, **kwargs: None)
 
-    context = {"event": {"id": "evt-3"}, "info": {"company_name": ""}, "event_id": "evt-3"}
+    context = {
+        "event": {
+            "id": "evt-3",
+            "summary": "Dossier review about acme.com",
+        },
+        "info": {"company_name": ""},
+        "event_id": "evt-3",
+    }
 
     result = await agent.continue_after_dossier_decision("audit-1", "Declined", context)
 
@@ -336,7 +361,10 @@ async def test_dossier_continuation_dispatches_when_complete(monkeypatch: pytest
     monkeypatch.setattr(agent, "_process_crm_dispatch", _fake_dispatch)
 
     context = {
-        "event": {"id": "evt-4"},
+        "event": {
+            "id": "evt-4",
+            "summary": "Dossier review about acme.com",
+        },
         "info": {"company_name": "Acme", "company_domain": "acme.com"},
         "event_id": "evt-4",
     }
@@ -365,7 +393,10 @@ async def test_dossier_continuation_requests_follow_up(monkeypatch: pytest.Monke
     monkeypatch.setattr(agent, "_process_crm_dispatch", lambda *args, **kwargs: None)
 
     context = {
-        "event": {"id": "evt-5"},
+        "event": {
+            "id": "evt-5",
+            "summary": "Dossier review about acme.com",
+        },
         "info": {"company_name": ""},
         "event_id": "evt-5",
     }
@@ -393,7 +424,10 @@ async def test_dossier_continuation_incomplete_returns_none(
     monkeypatch.setattr(agent, "_process_crm_dispatch", lambda *args, **kwargs: None)
 
     context = {
-        "event": {"id": "evt-8"},
+        "event": {
+            "id": "evt-8",
+            "summary": "Dossier review about acme.com",
+        },
         "info": {"company_name": ""},
         "event_id": "evt-8",
     }
@@ -438,7 +472,10 @@ async def test_dossier_follow_up_completion(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setattr(agent, "_process_crm_dispatch", _fake_dispatch)
 
     context = {
-        "event": {"id": "evt-7"},
+        "event": {
+            "id": "evt-7",
+            "summary": "Dossier review about acme.com",
+        },
         "info": {"company_name": ""},
         "event_id": "evt-7",
     }


### PR DESCRIPTION
## Summary
- ensure the extraction agent only keeps domains that occur within the event summary or description
- require company domain resolution to match event text and remove the organizer contact fallback
- adjust unit tests to cover the stricter domain acceptance rules

## Testing
- pytest --no-cov tests/unit/test_domain_resolution.py tests/unit/test_extraction_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68e4aae74548832bb220265e3cde017a