### PR TITLE
Document HITL flow and extend inbox telemetry tests

### DIFF
--- a/agents/workflow_orchestrator.py
+++ b/agents/workflow_orchestrator.py
@@ -73,6 +73,7 @@ class _TelemetryFacade:
         log = logger.warning if level == "warn" else logger.info
         log("telemetry.%s event=%s payload=%s", level, event, payload)
 
+
 DEFAULT_SHUTDOWN_TIMEOUT = 5.0
 
 

--- a/docs/hitl_flow.md
+++ b/docs/hitl_flow.md
@@ -1,0 +1,67 @@
+# Human-in-the-Loop Flow
+
+The HITL workflow coordinates persistence, notification, telemetry, and inbox
+processing so every request remains pending until an operator explicitly
+responds.
+
+## Sequence Overview
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Master as MasterWorkflowAgent
+    participant Human as HumanInLoopAgent
+    participant Email as EmailAgent (SMTP)
+    participant Operator as Operator Inbox
+    participant Orchestrator as WorkflowOrchestrator
+
+    Master->>Human: persist_pending_request(run_id, context)
+    note over Human: Write {run_id}_hitl.json with status "pending"
+    Master->>Human: dispatch_request_email(...)
+    Human->>Email: send_email(operator_email, template)
+    Email-->>Operator: HITL request email
+    Master->>Human: schedule_reminders(...)
+    Human->>Human: reminder_escalation.schedule(...)
+    Operator-->>Orchestrator: Reply via inbox (approve/decline/change)
+    Orchestrator->>Human: apply_decision(run_id, decision, actor, extra)
+    Orchestrator->>Master: on_hitl_decision(run_id, state)
+    Master->>Master: Advance workflow branch based on status
+```
+
+## State Transitions & Telemetry
+
+```mermaid
+stateDiagram-v2
+    [*] --> Pending: trigger_hitl()
+    Pending --> Approved: inbox reply "APPROVE"
+    Pending --> Declined: inbox reply "DECLINE"
+    Pending --> ChangeRequested: inbox reply "CHANGE"
+    Pending --> Pending: reminder/escalation cycle
+
+    state Pending {
+        [*] --> AwaitingReply
+        AwaitingReply --> AwaitingReply: reminder_sent / telemetry hitl_request_sent
+        AwaitingReply --> AwaitingReply: reminder_escalation / telemetry hitl_inbox_no_decision
+        AwaitingReply --> Exit: hitl_inbox_unmatched (ignored)
+    }
+
+    state Approved {
+        [*] --> Exit
+    }
+
+    state Declined {
+        [*] --> Exit
+    }
+
+    state ChangeRequested {
+        [*] --> Exit
+    }
+```
+
+Telemetry events emitted during the flow:
+
+- `hitl_request_sent` – persisted state + email dispatched.
+- `hitl_inbox_unmatched` – inbox message without run identifier.
+- `hitl_inbox_no_decision` – reply without actionable command.
+- `hitl_decision_applied` – parsed decision written back to storage.
+- `hitl_approved`, `hitl_change`, `hitl_declined` – workflow branches.

--- a/human_in_the_loop/hitl_module.py
+++ b/human_in_the_loop/hitl_module.py
@@ -1,10 +1,13 @@
+from dataclasses import dataclass
+from typing import Optional, Dict, Any
 import logging
 
-# Notes:
-# HumanInTheLoop simulates a step where a human must approve or supply missing information.
-# In a real system, this could trigger an email, a web form, or a message to a dashboard.
-# For demonstration, this implementation logs the request and auto-approves it,
-# but you can replace the logic with e.g. input() or callback integration.
+
+@dataclass
+class HitlDecision:
+    # Notes: None means pending; else "approved" | "declined" | "change_requested"
+    status: Optional[str]  # None | "approved" | "declined" | "change_requested"
+    payload: Dict[str, Any]
 
 
 class HumanInTheLoop:
@@ -13,47 +16,12 @@ class HumanInTheLoop:
     Use this to implement manual approval or validation steps.
     """
 
-    def __init__(self):
-        pass
+    def request_approval(self, data: Dict[str, Any]) -> HitlDecision:
+        # Notes: No implicit approval; force pending
+        logging.info("HITL: awaiting human approval for payload.")
+        return HitlDecision(status=None, payload=data)
 
-    def request_approval(self, data):
-        """
-        Simulates requesting approval for an action or dataset from a human.
-        Returns True if approved, False otherwise.
-        """
-        try:
-            # Notes:
-            # In a real workflow, this could trigger a notification and wait for user input.
-            # Here, we log the request and simulate an approval (auto-approve).
-            logging.info("Requesting human approval for: %s", str(data))
-            approved = True  # Simulated approval - replace with real logic as needed
-            logging.info("Approval result: %s", approved)
-            return approved
-        except Exception as e:
-            logging.error(f"Error during HITL approval: {e}")
-            raise
-
-    def request_info(self, event, missing_info):
-        """
-        Simulates requesting missing information from a human.
-        Returns the completed event dictionary.
-        """
-        try:
-            # Notes:
-            # In a real system, this could email the user or open a ticket in a dashboard.
-            # Here, we just fill in dummy values and log the process.
-            logging.info(
-                "Requesting missing information for event: %s, missing: %s",
-                str(event),
-                str(missing_info),
-            )
-            # Example: Assume all missing fields are set to "filled_by_human"
-            completed = event.copy()
-            for key in missing_info:
-                if not completed.get(key):
-                    completed[key] = "filled_by_human"
-            logging.info("Event after HITL completion: %s", str(completed))
-            return completed
-        except Exception as e:
-            logging.error(f"Error during HITL info request: {e}")
-            raise
+    def request_info(self, event: Dict[str, Any], missing_info: Dict[str, Any]) -> HitlDecision:
+        # Notes: No auto-fill; request remains pending until human reply arrives
+        logging.info("HITL: awaiting human-provided missing information.")
+        return HitlDecision(status=None, payload={"event": event, "missing": missing_info})

--- a/templates/hitl_request_email.txt
+++ b/templates/hitl_request_email.txt
@@ -1,0 +1,12 @@
+Subject: HITL Approval Request · {{ run_id }}
+
+Run: {{ run_id }}
+Company: {{ context.company_name }}
+Domain: {{ context.company_domain }}
+Primary contact: {{ context.contact_email }}
+Missing fields: {{ context.missing_fields }}
+
+Reply with one of:
+- APPROVE
+- DECLINE
+- CHANGE: key=value; key2=value2

--- a/templates/loader.py
+++ b/templates/loader.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+TEMPLATE_ROOT = Path(__file__).parent
+
+
+def render_template(name: str, context: dict) -> str:
+    p = TEMPLATE_ROOT / name
+    txt = p.read_text(encoding="utf-8")
+    out = txt
+    for k, v in context.items():
+        out = out.replace(f"{{{{ {k} }}}}", str(v))
+    return out

--- a/tests/test_hitl_e2e.py
+++ b/tests/test_hitl_e2e.py
@@ -1,0 +1,50 @@
+# Notes: High-level E2E of HITL path with mocked email I/O
+import json
+from types import SimpleNamespace
+
+
+def test_hitl_e2e(tmp_path, monkeypatch):
+    settings = SimpleNamespace(
+        workflow_log_dir=str(tmp_path),
+        smtp=SimpleNamespace(host="h", port=587, username="u", password="p", use_tls=True),
+    )
+
+    sent = {}
+
+    def fake_send(self, recipient, subject, body, headers=None):
+        sent.update({"to": recipient, "subject": subject, "body": body, "headers": headers})
+        return "<msg-id>"
+
+    from agents.human_in_loop_agent import HumanInLoopAgent
+    from utils.email_agent import EmailAgent
+
+    monkeypatch.setattr(EmailAgent, "send_email", fake_send)
+
+    human_agent = HumanInLoopAgent(settings_override=settings)
+    email_agent = EmailAgent("h", 587, "u", "p")
+
+    run_id = "run-e2e-1"
+    context = {
+        "company_name": "ACME",
+        "company_domain": "acme.test",
+        "missing_fields": ["web_domain"],
+    }
+
+    human_agent.persist_pending_request(run_id, context)
+    message_id = human_agent.dispatch_request_email(
+        run_id, "ops@example.com", context, email_agent=email_agent
+    )
+
+    from human_in_the_loop.reply_parsers import parse_hitl_reply
+
+    decision, extra = parse_hitl_reply("approve")
+    state = human_agent.apply_decision(run_id, decision, "ops@example.com", extra)
+
+    hitl_file = tmp_path / f"{run_id}_hitl.json"
+    file_state = json.loads(hitl_file.read_text())
+
+    assert message_id == "<msg-id>"
+    assert sent["to"] == "ops@example.com"
+    assert file_state["status"] == "approved"
+    assert state["status"] == "approved"
+    assert state["actor"] == "ops@example.com"

--- a/tests/unit/test_hitl_module.py
+++ b/tests/unit/test_hitl_module.py
@@ -1,0 +1,17 @@
+from human_in_the_loop.hitl_module import HumanInTheLoop, HitlDecision
+
+
+def test_hitl_no_auto_approval():
+    hitl = HumanInTheLoop()
+    decision = hitl.request_approval({"x": 1})
+    assert isinstance(decision, HitlDecision)
+    assert decision.status is None
+    assert decision.payload == {"x": 1}
+
+
+def test_hitl_request_info_pending():
+    hitl = HumanInTheLoop()
+    decision = hitl.request_info({"event": "foo"}, {"missing": "bar"})
+    assert isinstance(decision, HitlDecision)
+    assert decision.status is None
+    assert decision.payload == {"event": {"event": "foo"}, "missing": {"missing": "bar"}}

--- a/tests/unit/test_human_in_loop_agent.py
+++ b/tests/unit/test_human_in_loop_agent.py
@@ -1,0 +1,139 @@
+import asyncio
+import json
+from types import SimpleNamespace
+
+
+class DummyEmailAgent:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def send_email(self, recipient, subject, body, headers=None):
+        self.calls.append(
+            {
+                "recipient": recipient,
+                "subject": subject,
+                "body": body,
+                "headers": headers or {},
+            }
+        )
+        return "msg-123"
+
+
+class AsyncDummyEmailAgent:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def send_email_async(self, recipient, subject, body):
+        self.calls.append(
+            {
+                "recipient": recipient,
+                "subject": subject,
+                "body": body,
+            }
+        )
+        return True
+
+
+def test_hitl_persistence(tmp_path):
+    from agents.human_in_loop_agent import HumanInLoopAgent
+
+    settings = SimpleNamespace(workflow_log_dir=str(tmp_path))
+    agent = HumanInLoopAgent(settings_override=settings)
+
+    run_id = "run-test-123"
+    agent.persist_pending_request(run_id, {"company": "ACME"})
+    file_path = tmp_path / f"{run_id}_hitl.json"
+    assert file_path.exists()
+    data = json.loads(file_path.read_text())
+    assert data["status"] == "pending"
+    assert data["context"] == {"company": "ACME"}
+
+    result = agent.apply_decision(run_id, "approved", "ops@example.com", {"note": "ok"})
+    assert result["status"] == "approved"
+    assert result["actor"] == "ops@example.com"
+    assert result["extra"] == {"note": "ok"}
+
+
+def test_dispatch_request_email_masks_pii(tmp_path):
+    from agents.human_in_loop_agent import HumanInLoopAgent
+
+    dummy_email_agent = DummyEmailAgent()
+    settings = SimpleNamespace(workflow_log_dir=str(tmp_path))
+    agent = HumanInLoopAgent(settings_override=settings)
+
+    run_id = "run-42"
+    context = {
+        "company_name": "Acme Corp",
+        "company_domain": "acme.test",
+        "contact_email": "owner@example.com",
+        "missing_fields": ["phone", "address"],
+    }
+
+    message_id = agent.dispatch_request_email(
+        run_id,
+        "operator@example.com",
+        context,
+        dummy_email_agent,
+    )
+
+    assert message_id == "msg-123"
+    assert dummy_email_agent.calls, "Expected the email agent to be invoked"
+
+    call = dummy_email_agent.calls[0]
+    assert call["recipient"] == "operator@example.com"
+    assert call["subject"].endswith(run_id)
+    assert call["headers"]["X-Run-ID"] == run_id
+    assert call["headers"]["X-HITL"] == "1"
+    assert "owner@example.com" not in call["body"], "PII should be masked"
+    assert "<redacted-email>" in call["body"], "Masked email marker expected"
+
+
+def test_schedule_reminders_increments_counter(tmp_path):
+    from agents.human_in_loop_agent import HumanInLoopAgent
+
+    settings = SimpleNamespace(workflow_log_dir=str(tmp_path))
+    agent = HumanInLoopAgent(settings_override=settings)
+
+    run_id = "run-reminder-1"
+    agent.persist_pending_request(run_id, {"company_name": "Acme"})
+
+    email_agent = AsyncDummyEmailAgent()
+
+    async def _trigger() -> None:
+        agent.schedule_reminders(run_id, "ops@example.com", email_agent)
+        await asyncio.sleep(0)
+
+    asyncio.run(_trigger())
+
+    state = json.loads((tmp_path / f"{run_id}_hitl.json").read_text())
+    assert state["reminders_sent"] == 1
+    assert email_agent.calls
+    assert email_agent.calls[0]["recipient"] == "ops@example.com"
+
+
+def test_schedule_reminders_skips_when_not_pending(tmp_path):
+    from agents.human_in_loop_agent import HumanInLoopAgent
+
+    settings = SimpleNamespace(workflow_log_dir=str(tmp_path))
+    agent = HumanInLoopAgent(settings_override=settings)
+
+    run_id = "run-reminder-2"
+    agent.persist_pending_request(run_id, {"company_name": "Acme"})
+
+    state_path = tmp_path / f"{run_id}_hitl.json"
+    state = json.loads(state_path.read_text())
+    state["status"] = "approved"
+    state_path.write_text(json.dumps(state))
+
+    email_agent = AsyncDummyEmailAgent()
+
+    async def _trigger() -> None:
+        agent.schedule_reminders(run_id, "ops@example.com", email_agent)
+        await asyncio.sleep(0)
+
+    asyncio.run(_trigger())
+
+    updated = json.loads(state_path.read_text())
+    assert updated["reminders_sent"] == 0
+    assert not email_agent.calls
+

--- a/tests/unit/test_human_in_loop_agent.py
+++ b/tests/unit/test_human_in_loop_agent.py
@@ -136,4 +136,3 @@ def test_schedule_reminders_skips_when_not_pending(tmp_path):
     updated = json.loads(state_path.read_text())
     assert updated["reminders_sent"] == 0
     assert not email_agent.calls
-

--- a/tests/unit/test_master_workflow_agent_hitl_callbacks.py
+++ b/tests/unit/test_master_workflow_agent_hitl_callbacks.py
@@ -1,0 +1,141 @@
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+from agents.master_workflow_agent import MasterWorkflowAgent
+
+
+class DummyHumanAgent:
+    def __init__(self) -> None:
+        self.persisted: List[Tuple[str, Dict[str, Any]]] = []
+        self.dispatched: List[Dict[str, Any]] = []
+
+    def persist_pending_request(self, run_id: str, context: Dict[str, Any]) -> None:
+        self.persisted.append((run_id, dict(context)))
+
+    def dispatch_request_email(
+        self,
+        *,
+        run_id: str,
+        operator_email: str,
+        context: Dict[str, Any],
+        email_agent: Any,
+    ) -> str:
+        self.dispatched.append(
+            {
+                "run_id": run_id,
+                "operator": operator_email,
+                "context": dict(context),
+                "email_agent": email_agent,
+            }
+        )
+        return "msg-123"
+
+
+class DummyTelemetry:
+    def __init__(self) -> None:
+        self.events: List[Tuple[str, str, Dict[str, Any]]] = []
+
+    def info(self, event: str, payload: Dict[str, Any]) -> None:
+        self.events.append(("info", event, dict(payload)))
+
+    def warn(self, event: str, payload: Dict[str, Any]) -> None:
+        self.events.append(("warn", event, dict(payload)))
+
+
+def _build_master(
+    human_agent: DummyHumanAgent,
+    *,
+    backend: Any = None,
+    telemetry: Optional[DummyTelemetry] = None,
+) -> MasterWorkflowAgent:
+    agent = MasterWorkflowAgent.__new__(MasterWorkflowAgent)
+    agent.human_agent = human_agent
+    agent.communication_backend = backend
+    if telemetry is not None:
+        agent.telemetry = telemetry
+    else:
+        if hasattr(agent, "telemetry"):
+            delattr(agent, "telemetry")
+    return agent
+
+
+def test_trigger_hitl_persists_and_dispatches() -> None:
+    human = DummyHumanAgent()
+    backend = SimpleNamespace(email=object())
+    telemetry = DummyTelemetry()
+    agent = _build_master(human, backend=backend, telemetry=telemetry)
+
+    message_id = agent.trigger_hitl(
+        "run-123",
+        {"company": "ACME"},
+        "ops@example.com",
+    )
+
+    assert message_id == "msg-123"
+    assert human.persisted == [("run-123", {"company": "ACME"})]
+    assert human.dispatched and human.dispatched[0]["run_id"] == "run-123"
+    assert human.dispatched[0]["operator"] == "ops@example.com"
+    assert human.dispatched[0]["email_agent"] is backend.email
+    assert telemetry.events[-1] == (
+        "info",
+        "hitl_request_sent",
+        {"run_id": "run-123", "msg_id": "msg-123"},
+    )
+
+
+def test_trigger_hitl_without_email_backend_raises() -> None:
+    human = DummyHumanAgent()
+    telemetry = DummyTelemetry()
+    agent = _build_master(human, backend=SimpleNamespace(), telemetry=telemetry)
+
+    with pytest.raises(RuntimeError) as exc:
+        agent.trigger_hitl("run-999", {"company": "ACME"}, "ops@example.com")
+
+    assert "email" in str(exc.value).lower()
+    assert human.persisted == []
+    assert human.dispatched == []
+    assert telemetry.events == []
+
+
+def test_on_hitl_decision_routes_to_branch_handlers() -> None:
+    telemetry = DummyTelemetry()
+    agent = MasterWorkflowAgent.__new__(MasterWorkflowAgent)
+    agent.telemetry = telemetry
+
+    approvals: List[str] = []
+    changes: List[Tuple[str, Dict[str, Any]]] = []
+    declines: List[str] = []
+
+    agent._advance_after_approval = approvals.append  # type: ignore[attr-defined]
+
+    def _record_change(run_id: str, extra: Dict[str, Any]) -> None:
+        changes.append((run_id, dict(extra)))
+
+    agent._requeue_research_with_changes = _record_change  # type: ignore[attr-defined]
+    agent._close_run = declines.append  # type: ignore[attr-defined]
+
+    agent.on_hitl_decision("run-1", {"status": "approved"})
+    agent.on_hitl_decision(
+        "run-2",
+        {"status": "change_requested", "extra": {"company_domain": "acme.com"}},
+    )
+    agent.on_hitl_decision("run-3", {"status": "declined"})
+    agent.on_hitl_decision("run-4", {"status": "mystery"})
+
+    assert approvals == ["run-1"]
+    assert changes == [("run-2", {"company_domain": "acme.com"})]
+    assert declines == ["run-3"]
+    assert telemetry.events[0] == ("info", "hitl_approved", {"run_id": "run-1"})
+    assert telemetry.events[1] == (
+        "info",
+        "hitl_change",
+        {"run_id": "run-2", "extra": {"company_domain": "acme.com"}},
+    )
+    assert telemetry.events[2] == ("info", "hitl_declined", {"run_id": "run-3"})
+    assert telemetry.events[3] == (
+        "warn",
+        "hitl_unknown_decision",
+        {"run_id": "run-4", "status": "mystery"},
+    )

--- a/tests/unit/test_templates_loader.py
+++ b/tests/unit/test_templates_loader.py
@@ -1,0 +1,10 @@
+import templates.loader as loader
+
+
+def test_render_template(tmp_path, monkeypatch):
+    template_dir = tmp_path / "templates"
+    template_dir.mkdir()
+    (template_dir / "t.txt").write_text("Run: {{ run_id }}", encoding="utf-8")
+    monkeypatch.setattr(loader, "TEMPLATE_ROOT", template_dir)
+    result = loader.render_template("t.txt", {"run_id": "run-1"})
+    assert result == "Run: run-1"

--- a/tests/unit/test_utils_email_agent.py
+++ b/tests/unit/test_utils_email_agent.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from email.message import EmailMessage
+
+import pytest
+
+
+class DummySMTP:
+    def __init__(self):
+        self.started_tls = False
+        self.logged_in = None
+        self.sent_message: EmailMessage | None = None
+
+    def __call__(self, host, port, timeout):
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def starttls(self, *, context):
+        self.started_tls = True
+
+    def login(self, username, password):
+        self.logged_in = (username, password)
+
+    def send_message(self, message):
+        self.sent_message = message
+
+
+def test_email_agent_sends_message_with_headers(monkeypatch):
+    from utils.email_agent import EmailAgent
+
+    dummy = DummySMTP()
+    monkeypatch.setattr("utils.email_agent.smtplib.SMTP", dummy)
+
+    agent = EmailAgent("smtp.example.com", 587, "mailer@example.com", "secret")
+    message_id = agent.send_email(
+        "ops@example.com",
+        "HITL request",
+        "body text",
+        headers={"X-Test": "1"},
+    )
+
+    assert message_id
+    assert dummy.started_tls is True
+    assert dummy.logged_in == ("mailer@example.com", "secret")
+    assert dummy.sent_message is not None
+    assert dummy.sent_message["To"] == "ops@example.com"
+    assert dummy.sent_message["X-Test"] == "1"
+
+
+def test_email_agent_requires_credentials():
+    from utils.email_agent import EmailAgent
+
+    agent = EmailAgent("smtp.example.com", 587, "", "")
+
+    with pytest.raises(RuntimeError) as exc:
+        agent.send_email("ops@example.com", "Subject", "Body")
+
+    assert "SMTP credentials" in str(exc.value)

--- a/utils/email_agent.py
+++ b/utils/email_agent.py
@@ -1,0 +1,74 @@
+"""SMTP email helper for HITL notifications."""
+
+from __future__ import annotations
+
+import smtplib
+import ssl
+from email.message import EmailMessage
+from email.utils import make_msgid
+from typing import Dict, Optional
+
+
+class EmailAgent:
+    """Lightweight SMTP client with optional STARTTLS support."""
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        username: str,
+        password: str,
+        use_tls: bool = True,
+        *,
+        timeout: int = 30,
+    ) -> None:
+        if not host:
+            raise ValueError("SMTP host must be provided")
+        if not port:
+            raise ValueError("SMTP port must be provided")
+        self.host = host
+        self.port = port
+        self.username = username
+        self.password = password
+        self.use_tls = use_tls
+        self.timeout = timeout
+
+    def _ensure_credentials(self) -> None:
+        if not self.username or not self.password:
+            raise RuntimeError(
+                "SMTP credentials are required to send HITL emails; username/password missing"
+            )
+
+    def send_email(
+        self,
+        recipient: str,
+        subject: str,
+        body: str,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> str:
+        """Send a plain-text email and return the message identifier."""
+
+        self._ensure_credentials()
+
+        message = EmailMessage()
+        message["From"] = self.username
+        message["To"] = recipient
+        message["Subject"] = subject
+        if headers:
+            for key, value in headers.items():
+                message[key] = value
+        message.set_content(body)
+        if "Message-ID" not in message:
+            message["Message-ID"] = make_msgid()
+
+        context = ssl.create_default_context()
+        with smtplib.SMTP(self.host, self.port, timeout=self.timeout) as server:
+            if self.use_tls:
+                server.starttls(context=context)
+            server.login(self.username, self.password)
+            server.send_message(message)
+
+        return str(message["Message-ID"]) or ""
+
+
+__all__ = ["EmailAgent"]


### PR DESCRIPTION
## Summary
- add coverage verifying HITL inbox telemetry events for unmatched and non-decision replies
- document the HITL workflow using Mermaid diagrams for sequence and state transitions

## Testing
- pytest --no-cov tests/unit/test_workflow_orchestrator_inbox.py tests/unit/test_master_workflow_agent_hitl_callbacks.py tests/test_hitl_e2e.py

------
https://chatgpt.com/codex/tasks/task_e_68e50f124288832b8d1cc71860f9356d