### PR TITLE
Persist CRM lookup artifacts per event

### DIFF
--- a/docs/hubspot_dossier_audit.md
+++ b/docs/hubspot_dossier_audit.md
@@ -201,7 +201,7 @@ Jede Anfrage/Antwort erzeugt Audit-Einträge (`request_type`, `stage`, `responde
     },
     "artifacts": {
       "neighbor_samples": "log_storage/run_history/research/artifacts/internal_research/<run_id>/level1_samples.json",
-      "crm_match": ".../crm_matching_company.json"
+      "crm_match": ".../crm_match_<event_id>.json"
     }
   }
 }
@@ -261,7 +261,7 @@ Normalisierung & Detail-Anreicherung erfolgen nach Backend-Response und Audit-Pr
 ## 7) Logging- & Artefakt-Ablage (mit Pfad-Referenzen)
 - `log_storage/run_history/workflows/<run_id>.jsonl`: sequenzielle Workflow-Logs vom WorkflowLogManager.【F:logs/workflow_log_manager.py†L17-L59】【F:agents/master_workflow_agent.py†L360-L439】
 - `log_storage/run_history/agents/internal_research/internal_research.log`: dedizierte Agent-Logs durch `_configure_file_logger`.【F:agents/internal_research_agent.py†L54-L109】
-- `log_storage/run_history/research/artifacts/internal_research/<run_id>/level1_samples.json` & `crm_matching_company.json`: Artefakte aus InternalResearch.【F:agents/internal_research_agent.py†L112-L167】
+- `log_storage/run_history/research/artifacts/internal_research/<run_id>/level1_samples.json` & `crm_match_<event_id>.json`: Artefakte aus InternalResearch.【F:agents/internal_research_agent.py†L112-L167】
 - `log_storage/run_history/research/artifacts/dossier_research/<run_id>/<event_id>_company_detail_research.json`: Persistiertes Dossier.【F:agents/dossier_research_agent.py†L58-L205】
 - `log_storage/run_history/research/artifacts/similar_companies_level1/<run_id>/...`: Similar-Research, sofern aktiviert.【F:agents/int_lvl_1_agent.py†L98-L170】
 - `log_storage/run_history/research/artifacts/workflow_runs/<run_id>/summary.json`: Run-Summary vom Workflow-Orchestrator.【F:agents/workflow_orchestrator.py†L611-L637】
@@ -274,7 +274,7 @@ Beispielstruktur:
 log_storage/run_history/
 ├── agents/internal_research/internal_research.log
 ├── research/artifacts/
-│   ├── internal_research/<run_id>/crm_matching_company.json
+│   ├── internal_research/<run_id>/crm_match_<event_id>.json
 │   ├── dossier_research/<run_id>/<event_id>_company_detail_research.json
 │   ├── similar_companies_level1/<run_id>/...
 │   └── workflow_runs/<run_id>/summary.json

--- a/docs/run_history_file_map.md
+++ b/docs/run_history_file_map.md
@@ -15,8 +15,8 @@ Die folgende Übersicht dokumentiert, welche Komponenten die wichtigsten Dateien
 - **Bezug zum Laufkontext:** Ordner- und Dateinamen enthalten `run_id` und `event_id`, wodurch Artefakte eindeutig dem Workflow-Run zugeordnet sind.【F:agents/dossier_research_agent.py†L68-L205】
 
 ## `log_storage/run_history/research/artifacts/internal_research`
-- **Verantwortliche Komponente:** `InternalResearchAgent` persistiert ergänzende JSON-Artefakte (z. B. `level1_samples.json`, `crm_matching_company.json`) unterhalb von `<run_id>`.【F:agents/internal_research_agent.py†L81-L155】【F:agents/internal_research_agent.py†L464-L493】
-- **Inhalt & Datenstruktur:** Die Dateien enthalten Listen von Nachbarunternehmen bzw. CRM-Matching-Daten, die aus dem Trigger abgeleitet werden.【F:agents/internal_research_agent.py†L136-L195】【F:agents/internal_research_agent.py†L445-L493】
+- **Verantwortliche Komponente:** `InternalResearchAgent` persistiert ergänzende JSON-Artefakte (z. B. `level1_samples.json`, `crm_match_<event_id>.json`) unterhalb von `<run_id>`.【F:agents/internal_research_agent.py†L81-L155】【F:agents/internal_research_agent.py†L418-L493】
+- **Inhalt & Datenstruktur:** Die Dateien enthalten Listen von Nachbarunternehmen bzw. vollständige CRM-Lookup-Payloads (`crm_lookup` mit Flags, Attachments, Company-Objekt, Zeitstempel).【F:agents/internal_research_agent.py†L136-L195】【F:agents/internal_research_agent.py†L418-L493】
 - **Verwendungszweck im Workflow:** Die Pfade werden im normalisierten Agentenergebnis zurückgegeben (`payload.artifacts`), sodass der Master-Workflow sie in Audit-Trails und CRM-Workflows referenzieren kann.【F:agents/internal_research_agent.py†L178-L195】
 - **Bezug zum Laufkontext:** Unterordner nach `run_id` stellen sicher, dass mehrere Runs eines Unternehmens getrennt bleiben; Artefaktverweise tauchen im Run-Summary (`research`) wieder auf.【F:agents/internal_research_agent.py†L464-L472】【F:agents/workflow_orchestrator.py†L621-L635】
 

--- a/tests/integration/test_workflow_orchestrator_integration.py
+++ b/tests/integration/test_workflow_orchestrator_integration.py
@@ -247,7 +247,7 @@ async def test_orchestrator_records_research_artifacts_and_email_details(
                         "existing_report": False,
                         "artifacts": {
                             "neighbor_samples": "stub/level1_samples.json",
-                            "crm_match": "stub/crm_matching_company.json",
+                            "crm_match": "stub/crm_match_evt-456.json",
                         },
                     },
                 },
@@ -314,7 +314,7 @@ async def test_orchestrator_records_research_artifacts_and_email_details(
     internal_payload = entry["research"]["internal_research"]["payload"]
     assert internal_payload["action"] == "REPORT_REQUIRED"
     assert (
-        internal_payload["artifacts"]["crm_match"] == "stub/crm_matching_company.json"
+        internal_payload["artifacts"]["crm_match"] == "stub/crm_match_evt-456.json"
     )
 
     dossier_payload = entry["research"]["dossier_research"]["payload"]

--- a/utils/crm_artifacts.py
+++ b/utils/crm_artifacts.py
@@ -1,0 +1,80 @@
+"""Helpers for persisting CRM lookup artifacts for the internal research agent."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class CrmMatchArtifact:
+    """Serializable representation of a CRM match artifact."""
+
+    run_id: str
+    event_id: Optional[str]
+    company_name: str
+    company_domain: str
+    crm_lookup: Dict[str, Any]
+    written_at: str
+
+
+def build_crm_match_payload(
+    *,
+    run_id: str,
+    event_id: Optional[str],
+    company_name: str,
+    company_domain: str,
+    crm_lookup: Dict[str, Any],
+    timestamp: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Create a JSON-serialisable payload for a CRM match artifact."""
+
+    artifact = CrmMatchArtifact(
+        run_id=run_id,
+        event_id=str(event_id) if event_id is not None else None,
+        company_name=company_name,
+        company_domain=company_domain,
+        crm_lookup=crm_lookup,
+        written_at=timestamp or datetime.now(timezone.utc).isoformat(),
+    )
+    return asdict(artifact)
+
+
+def persist_crm_match(
+    artifact_root: Path,
+    run_id: str,
+    event_id: Optional[str],
+    payload: Dict[str, Any],
+) -> Path:
+    """Persist the CRM match payload in an event-scoped JSON artifact."""
+
+    run_dir = artifact_root / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    safe_event = _sanitise_identifier(event_id)
+    if not safe_event:
+        safe_event = f"{_sanitise_identifier(run_id) or 'run'}_{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S%f')}"
+
+    out_file = run_dir / f"crm_match_{safe_event}.json"
+    _atomic_write_json(out_file, payload)
+    return out_file
+
+
+def _sanitise_identifier(value: Optional[str]) -> str:
+    if value is None:
+        return ""
+    text = str(value)
+    text = re.sub(r"[^0-9A-Za-z._-]", "_", text)
+    text = text.strip("._-")
+    return text
+
+
+def _atomic_write_json(path: Path, payload: Dict[str, Any]) -> None:
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    with tmp_path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2)
+    tmp_path.replace(path)


### PR DESCRIPTION
## Summary
- persist the full CRM lookup payload per event using event-scoped artifact files and explicit logging
- add a CRM artifact utility helper and adjust documentation and tests to the new artifact naming

## Testing
- pytest --no-cov tests/unit/test_internal_research_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68e5917202a0832b8f067042b6d23669