### PR TITLE
Implement domain HITL guardrail and SMTP safeguards

### DIFF
--- a/agents/internal_research_agent.py
+++ b/agents/internal_research_agent.py
@@ -16,7 +16,7 @@ from integration.hubspot_integration import HubSpotIntegration
 from config.config import settings
 from logs.workflow_log_manager import WorkflowLogManager
 from reminders.reminder_escalation import ReminderEscalation
-from utils.crm_artifacts import build_crm_match_payload, persist_crm_match
+from utils.crm_artifacts import save_crm_match
 from utils.persistence import atomic_write_json
 
 NormalizedPayload = Dict[str, Any]
@@ -462,13 +462,12 @@ class InternalResearchAgent(BaseResearchAgent):
             or ""
         )
 
-        artifact_payload = build_crm_match_payload(
-            run_id=run_id,
-            event_id=event_id,
-            company_name=company_name,
-            company_domain=company_domain,
-            crm_lookup=dict(crm_lookup),
-        )
+        artifact_payload = {
+            "company_name": company_name,
+            "company_domain": company_domain,
+            "request_payload": dict(payload),
+            "crm_lookup": dict(crm_lookup),
+        }
 
         self.logger.info(
             "Persisting CRM match artifact for run %s event %s: %s",
@@ -477,10 +476,10 @@ class InternalResearchAgent(BaseResearchAgent):
             json.dumps(artifact_payload, ensure_ascii=False, sort_keys=True),
         )
 
-        artifact_path = persist_crm_match(
+        artifact_path = save_crm_match(
             self.research_artifact_dir,
             run_id,
-            event_id,
+            str(event_id) if event_id is not None else None,
             artifact_payload,
         )
         return artifact_path.as_posix()

--- a/tests/unit/test_internal_research_agent.py
+++ b/tests/unit/test_internal_research_agent.py
@@ -286,9 +286,10 @@ def test_persist_crm_match_artifact_writes_full_payload(agent):
     contents = json.loads(path_obj.read_text(encoding="utf-8"))
     assert contents["run_id"] == "run-xyz"
     assert contents["event_id"] == "evt-123"
-    assert contents["company_name"] == "Hooli"
-    assert contents["company_domain"] == "hooli.com"
-    assert contents["crm_lookup"] == crm_lookup
+    assert contents["crm_payload"]["company_name"] == "Hooli"
+    assert contents["crm_payload"]["company_domain"] == "hooli.com"
+    assert contents["crm_payload"]["crm_lookup"] == crm_lookup
+    assert contents["crm_payload"]["request_payload"] == payload
     assert "written_at" in contents
 
 
@@ -311,7 +312,7 @@ def test_persist_crm_match_artifact_handles_missing_event(agent):
     assert path_obj.name.startswith("crm_match_run-xyz_")
     contents = json.loads(path_obj.read_text(encoding="utf-8"))
     assert contents["event_id"] is None
-    assert contents["company_domain"] == "umbrella.example"
+    assert contents["crm_payload"]["company_domain"] == "umbrella.example"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_utils_email_agent.py
+++ b/tests/unit/test_utils_email_agent.py
@@ -23,6 +23,9 @@ class DummySMTP:
     def __exit__(self, exc_type, exc, tb):
         return False
 
+    def ehlo(self):
+        return ("dummy", "ok")
+
     def starttls(self, *, context):
         self.started_tls = True
 

--- a/utils/crm_artifacts.py
+++ b/utils/crm_artifacts.py
@@ -1,65 +1,37 @@
-"""Helpers for persisting CRM lookup artifacts for the internal research agent."""
-
 from __future__ import annotations
 
 import json
 import re
-from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
 
 
-@dataclass
-class CrmMatchArtifact:
-    """Serializable representation of a CRM match artifact."""
-
-    run_id: str
-    event_id: Optional[str]
-    company_name: str
-    company_domain: str
-    crm_lookup: Dict[str, Any]
-    written_at: str
-
-
-def build_crm_match_payload(
-    *,
+def save_crm_match(
+    base_dir: Path,
     run_id: str,
     event_id: Optional[str],
-    company_name: str,
-    company_domain: str,
-    crm_lookup: Dict[str, Any],
-    timestamp: Optional[str] = None,
-) -> Dict[str, Any]:
-    """Create a JSON-serialisable payload for a CRM match artifact."""
-
-    artifact = CrmMatchArtifact(
-        run_id=run_id,
-        event_id=str(event_id) if event_id is not None else None,
-        company_name=company_name,
-        company_domain=company_domain,
-        crm_lookup=crm_lookup,
-        written_at=timestamp or datetime.now(timezone.utc).isoformat(),
-    )
-    return asdict(artifact)
-
-
-def persist_crm_match(
-    artifact_root: Path,
-    run_id: str,
-    event_id: Optional[str],
-    payload: Dict[str, Any],
+    crm_payload: Dict[str, Any],
 ) -> Path:
-    """Persist the CRM match payload in an event-scoped JSON artifact."""
+    """Persist a CRM payload to an event-scoped artifact."""
 
-    run_dir = artifact_root / run_id
-    run_dir.mkdir(parents=True, exist_ok=True)
+    out_dir = base_dir / run_id
+    out_dir.mkdir(parents=True, exist_ok=True)
 
     safe_event = _sanitise_identifier(event_id)
     if not safe_event:
-        safe_event = f"{_sanitise_identifier(run_id) or 'run'}_{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S%f')}"
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%f")
+        safe_run = _sanitise_identifier(run_id) or "run"
+        safe_event = f"{safe_run}_{timestamp}"
 
-    out_file = run_dir / f"crm_match_{safe_event}.json"
+    payload = {
+        "run_id": run_id,
+        "event_id": str(event_id) if event_id is not None else None,
+        "crm_payload": crm_payload,
+        "written_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    out_file = out_dir / f"crm_match_{safe_event}.json"
     _atomic_write_json(out_file, payload)
     return out_file
 
@@ -69,8 +41,7 @@ def _sanitise_identifier(value: Optional[str]) -> str:
         return ""
     text = str(value)
     text = re.sub(r"[^0-9A-Za-z._-]", "_", text)
-    text = text.strip("._-")
-    return text
+    return text.strip("._-")
 
 
 def _atomic_write_json(path: Path, payload: Dict[str, Any]) -> None:
@@ -78,3 +49,6 @@ def _atomic_write_json(path: Path, payload: Dict[str, Any]) -> None:
     with tmp_path.open("w", encoding="utf-8") as handle:
         json.dump(payload, handle, ensure_ascii=False, indent=2)
     tmp_path.replace(path)
+
+
+__all__ = ["save_crm_match"]

--- a/utils/email_agent.py
+++ b/utils/email_agent.py
@@ -2,15 +2,88 @@
 
 from __future__ import annotations
 
+import os
 import smtplib
 import ssl
 from email.message import EmailMessage
 from email.utils import make_msgid
 from typing import Dict, Optional
 
+DEFAULT_TIMEOUT = 30
+
+
+def _normalize_bool(value: Optional[str], *, default: bool) -> bool:
+    if value is None:
+        return default
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _validate_mode(port: int, use_ssl: bool, use_starttls: bool) -> None:
+    if use_ssl and use_starttls:
+        raise RuntimeError("Invalid config: USE_SSL and STARTTLS cannot both be true.")
+    if port == 465 and use_starttls:
+        raise RuntimeError("Port 465 must not use STARTTLS.")
+    if port == 587 and not use_starttls:
+        raise RuntimeError("Port 587 requires STARTTLS.")
+
+
+def _build_message(
+    sender: str,
+    recipient: str,
+    subject: str,
+    body: str,
+    headers: Optional[Dict[str, str]] = None,
+) -> EmailMessage:
+    message = EmailMessage()
+    message["From"] = sender
+    message["To"] = recipient
+    message["Subject"] = subject
+    if headers:
+        for key, value in headers.items():
+            message[key] = value
+    message.set_content(body)
+    if "Message-ID" not in message:
+        message["Message-ID"] = make_msgid()
+    return message
+
+
+def send_mail(to: str, subject: str, body: str, *, timeout: int = DEFAULT_TIMEOUT) -> None:
+    """Send a simple email using SMTP settings sourced from the environment."""
+
+    host = os.environ["SMTP_HOST"]
+    port = int(os.environ.get("SMTP_PORT", "465"))
+    use_ssl = _normalize_bool(os.environ.get("SMTP_USE_SSL"), default=(port == 465))
+    use_starttls = _normalize_bool(
+        os.environ.get("SMTP_STARTTLS"), default=(port == 587)
+    )
+    _validate_mode(port, use_ssl, use_starttls)
+
+    username = os.environ.get("SMTP_USERNAME")
+    password = os.environ.get("SMTP_PASSWORD")
+    sender = os.environ.get("SMTP_FROM") or username or "noreply@example.com"
+
+    message = _build_message(sender, to, subject, body)
+
+    if use_ssl or port == 465:
+        context = ssl.create_default_context()
+        with smtplib.SMTP_SSL(host, port, context=context, timeout=timeout) as smtp:
+            if username and password:
+                smtp.login(username, password)
+            smtp.send_message(message)
+    else:
+        with smtplib.SMTP(host, port, timeout=timeout) as smtp:
+            smtp.ehlo()
+            if use_starttls:
+                context = ssl.create_default_context()
+                smtp.starttls(context=context)
+                smtp.ehlo()
+            if username and password:
+                smtp.login(username, password)
+            smtp.send_message(message)
+
 
 class EmailAgent:
-    """Lightweight SMTP client with optional STARTTLS support."""
+    """Lightweight SMTP client with configurable TLS/SSL handling."""
 
     def __init__(
         self,
@@ -18,20 +91,32 @@ class EmailAgent:
         port: int,
         username: str,
         password: str,
-        use_tls: bool = True,
+        sender: Optional[str] = None,
         *,
-        timeout: int = 30,
+        use_ssl: Optional[bool] = None,
+        use_starttls: Optional[bool] = None,
+        timeout: int = DEFAULT_TIMEOUT,
     ) -> None:
         if not host:
             raise ValueError("SMTP host must be provided")
         if not port:
             raise ValueError("SMTP port must be provided")
         self.host = host
-        self.port = port
+        self.port = int(port)
         self.username = username
         self.password = password
-        self.use_tls = use_tls
+        self.sender = sender or username or "noreply@example.com"
         self.timeout = timeout
+
+        if use_ssl is None and use_starttls is None:
+            inferred_ssl = self.port == 465
+            inferred_starttls = self.port == 587
+        else:
+            inferred_ssl = bool(use_ssl)
+            inferred_starttls = bool(use_starttls)
+        _validate_mode(self.port, inferred_ssl, inferred_starttls)
+        self._use_ssl = inferred_ssl
+        self._use_starttls = inferred_starttls
 
     def _ensure_credentials(self) -> None:
         if not self.username or not self.password:
@@ -49,26 +134,26 @@ class EmailAgent:
         """Send a plain-text email and return the message identifier."""
 
         self._ensure_credentials()
+        message = _build_message(self.sender, recipient, subject, body, headers=headers)
 
-        message = EmailMessage()
-        message["From"] = self.username
-        message["To"] = recipient
-        message["Subject"] = subject
-        if headers:
-            for key, value in headers.items():
-                message[key] = value
-        message.set_content(body)
-        if "Message-ID" not in message:
-            message["Message-ID"] = make_msgid()
-
-        context = ssl.create_default_context()
-        with smtplib.SMTP(self.host, self.port, timeout=self.timeout) as server:
-            if self.use_tls:
-                server.starttls(context=context)
-            server.login(self.username, self.password)
-            server.send_message(message)
+        if self._use_ssl or self.port == 465:
+            context = ssl.create_default_context()
+            with smtplib.SMTP_SSL(
+                self.host, self.port, context=context, timeout=self.timeout
+            ) as smtp:
+                smtp.login(self.username, self.password)
+                smtp.send_message(message)
+        else:
+            with smtplib.SMTP(self.host, self.port, timeout=self.timeout) as smtp:
+                smtp.ehlo()
+                if self._use_starttls:
+                    context = ssl.create_default_context()
+                    smtp.starttls(context=context)
+                    smtp.ehlo()
+                smtp.login(self.username, self.password)
+                smtp.send_message(message)
 
         return str(message["Message-ID"]) or ""
 
 
-__all__ = ["EmailAgent"]
+__all__ = ["EmailAgent", "send_mail"]

--- a/validators/domain_utils.py
+++ b/validators/domain_utils.py
@@ -1,0 +1,44 @@
+"""Domain validation helpers and HITL triggers."""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Optional
+
+from utils.email_agent import send_mail
+
+DOMAIN_RE = re.compile(r"^(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\.[A-Za-z0-9-]{1,63})+$")
+
+
+def is_placeholder(domain: Optional[str]) -> bool:
+    """Return True when a domain is missing, malformed, or a test domain."""
+
+    if not domain or not isinstance(domain, str):
+        return True
+    cleaned = domain.strip().lower()
+    if not cleaned:
+        return True
+    return not DOMAIN_RE.match(cleaned) or cleaned.endswith(".test")
+
+
+def trigger_hitl_if_needed(event_id: str, company_name: str, company_domain: Optional[str]) -> bool:
+    """Send a HITL notification when the domain looks like a placeholder."""
+
+    if not is_placeholder(company_domain):
+        return False
+
+    operator = os.environ.get("HITL_OPERATOR_EMAIL")
+    if not operator:
+        raise RuntimeError("HITL_OPERATOR_EMAIL must be configured for HITL notifications")
+
+    subject = f"[HITL] Clarify domain for {company_name or 'unknown company'}"
+    body = (
+        f"Event {event_id}: placeholder or missing domain ({company_domain}).\n"
+        "Please reply with the correct domain."
+    )
+    send_mail(operator, subject, body)
+    return True
+
+
+__all__ = ["DOMAIN_RE", "is_placeholder", "trigger_hitl_if_needed"]


### PR DESCRIPTION
## Summary
- add validators to detect placeholder domains and trigger early HITL notifications
- update SMTP helper to handle implicit SSL and STARTTLS based on configuration and expose a send_mail utility
- persist CRM lookup artifacts per event and adjust tests for new HITL flow and CRM payload structure

## Testing
- PYTEST_ADDOPTS="--no-cov" pytest tests/unit/test_utils_email_agent.py
- PYTEST_ADDOPTS="--no-cov" pytest tests/unit/test_internal_research_agent.py
- PYTEST_ADDOPTS="--no-cov" pytest tests/test_master_workflow_agent_hitl.py


------
https://chatgpt.com/codex/tasks/task_e_68e59a0f4dfc832bbd384f7774cf6909