### PR TITLE
Task 1.5b: Integrate HITLDecisionEvaluator into MasterWorkflowAgent and propagate reason

### DIFF
--- a/agents/hitl_decision_evaluator.py
+++ b/agents/hitl_decision_evaluator.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Dict, Sequence, Tuple
+
+
+class HITLDecisionEvaluator:
+    """
+    # Notes:
+    # - Centralized logic whether a human-in-the-loop step is required.
+    # - Returns (hitl_required: bool, reason: str)
+    # - Easily extensible with new rules, weights, or ML-based confidence.
+    """
+
+    def __init__(
+        self,
+        *,
+        confidence_threshold: float = 0.80,
+        required_fields: Sequence[str] = ("company_domain",),
+        crm_attachment_rule: bool = True,
+    ) -> None:
+        self.confidence_threshold = confidence_threshold
+        self.required_fields = tuple(required_fields)
+        self.crm_attachment_rule = crm_attachment_rule
+
+    def evaluate(self, context: Dict) -> Tuple[bool, str]:
+        # Notes: 1) Missing critical fields
+        missing = [field for field in self.required_fields if not context.get(field)]
+        if missing:
+            return True, f"Missing fields: {', '.join(missing)}"
+
+        # Notes: 2) Low confidence from upstream extraction/classification
+        confidence = context.get("confidence_score")
+        if confidence is not None and confidence < self.confidence_threshold:
+            return True, f"Low confidence score: {confidence} < {self.confidence_threshold}"
+
+        # Notes: 3) CRM attachments require human review (if enabled)
+        if (
+            self.crm_attachment_rule
+            and context.get("company_in_crm")
+            and context.get("attachments_in_crm")
+        ):
+            return True, "CRM attachments require review"
+
+        return False, "All checks passed"

--- a/config/config.py
+++ b/config/config.py
@@ -616,6 +616,11 @@ class Settings:
         self.hitl_escalation_email: Optional[str] = _get_env_var(
             "HITL_ESCALATION_EMAIL"
         )
+        self.hitl_confidence_threshold: float = _get_float_env(
+            "HITL_CONFIDENCE_THRESHOLD", 0.80
+        )
+        # Notes: Provide uppercase alias for legacy access patterns
+        self.HITL_CONFIDENCE_THRESHOLD = self.hitl_confidence_threshold
         self.hitl_admin_reminder_hours: Tuple[float, ...] = self._parse_hitl_hours(
             _get_env_var("HITL_ADMIN_REMINDER_HOURS"),
             default=(24.0,),

--- a/human_in_the_loop/reply_parsers.py
+++ b/human_in_the_loop/reply_parsers.py
@@ -65,19 +65,40 @@ def extract_run_id(message: Any) -> Optional[str]:
     return None
 
 
+def _contains_command(text: str, tokens: Tuple[str, ...]) -> bool:
+    """Return ``True`` when *text* contains any of *tokens* as standalone words."""
+
+    for token in tokens:
+        if re.search(rf"\b{re.escape(token)}\b", text, re.IGNORECASE):
+            return True
+    return False
+
+
 def parse_hitl_reply(body: str) -> Tuple[Optional[str], Dict[str, str]]:
     """Parse a HITL reply body into a decision and optional key/value payload."""
 
     normalised = (body or "").strip()
-    upper = normalised.upper()
-    if "APPROVE" in upper:
+    if not normalised:
+        return None, {}
+
+    # Notes: Collapse whitespace while preserving individual lines for command detection
+    lines = [line.strip() for line in normalised.splitlines() if line.strip()]
+    text = "\n".join(lines)
+
+    approve_tokens = ("approve", "approved", "yes", "yep", "sure")
+    decline_tokens = ("decline", "declined", "no", "nope", "reject", "rejected", "disapprove", "disapproved")
+
+    if _contains_command(text, approve_tokens):
         return "approved", {}
-    if "DECLINE" in upper:
+    if _contains_command(text, decline_tokens):
         return "declined", {}
-    if "CHANGE" in upper:
-        pairs = re.findall(r"([A-Z0-9_]+)\s*=\s*([^\s;,\n]+)", normalised, re.IGNORECASE)
-        payload = {key.lower(): value for key, value in pairs}
-        return "change_requested", payload
+
+    for line in lines:
+        if re.match(r"^change\b", line, re.IGNORECASE):
+            pairs = re.findall(r"([A-Z0-9_]+)\s*=\s*([^\s;,\n]+)", normalised, re.IGNORECASE)
+            payload = {key.lower(): value for key, value in pairs}
+            return "change_requested", payload
+
     return None, {}
 
 

--- a/templates/hitl_request_email.txt
+++ b/templates/hitl_request_email.txt
@@ -5,6 +5,7 @@ Company: {{ context.company_name }}
 Domain: {{ context.company_domain }}
 Primary contact: {{ context.contact_email }}
 Missing fields: {{ context.missing_fields }}
+Reason: {{ context.hitl_reason }}
 
 Reply with one of:
 - APPROVE

--- a/tests/unit/test_config_hitl_threshold.py
+++ b/tests/unit/test_config_hitl_threshold.py
@@ -1,0 +1,19 @@
+import os
+from importlib import reload
+
+
+def test_hitl_threshold_default(monkeypatch):
+    monkeypatch.delenv("HITL_CONFIDENCE_THRESHOLD", raising=False)
+    import config.config as cfg
+
+    reload(cfg)
+    assert 0.79 < cfg.settings.HITL_CONFIDENCE_THRESHOLD < 0.81
+
+
+def test_hitl_threshold_from_env(monkeypatch):
+    monkeypatch.setenv("HITL_CONFIDENCE_THRESHOLD", "0.9")
+    import config.config as cfg
+
+    reload(cfg)
+    assert abs(cfg.settings.HITL_CONFIDENCE_THRESHOLD - 0.9) < 1e-6
+

--- a/tests/unit/test_hitl_decision_evaluator.py
+++ b/tests/unit/test_hitl_decision_evaluator.py
@@ -1,0 +1,29 @@
+from agents.hitl_decision_evaluator import HITLDecisionEvaluator
+
+
+def test_hitl_required_missing_fields():
+    ev = HITLDecisionEvaluator()
+    hitl, reason = ev.evaluate({"company_domain": ""})
+    assert hitl is True and "Missing fields" in reason
+
+
+def test_hitl_required_low_confidence():
+    ev = HITLDecisionEvaluator(confidence_threshold=0.9)
+    hitl, reason = ev.evaluate({"company_domain": "acme.test", "confidence_score": 0.5})
+    assert hitl is True and "Low confidence" in reason
+
+
+def test_hitl_required_crm_attachments():
+    ev = HITLDecisionEvaluator()
+    hitl, reason = ev.evaluate({
+        "company_domain": "acme.test",
+        "company_in_crm": True,
+        "attachments_in_crm": True,
+    })
+    assert hitl is True and "attachments" in reason
+
+
+def test_no_hitl_all_good():
+    ev = HITLDecisionEvaluator()
+    hitl, reason = ev.evaluate({"company_domain": "acme.test", "confidence_score": 0.95})
+    assert hitl is False and reason == "All checks passed"

--- a/tests/unit/test_master_workflow_agent_hitl_evaluator.py
+++ b/tests/unit/test_master_workflow_agent_hitl_evaluator.py
@@ -1,0 +1,97 @@
+from types import SimpleNamespace
+from typing import Any, Dict, List, Tuple
+
+from agents.master_workflow_agent import MasterWorkflowAgent
+
+
+class DummyHuman:
+    def __init__(self) -> None:
+        self.persist_calls: List[Tuple[str, Dict[str, Any]]] = []
+        self.dispatch_calls: List[Dict[str, Any]] = []
+
+    def persist_pending_request(self, run_id: str, context: Dict[str, Any]) -> None:
+        self.persist_calls.append((run_id, dict(context)))
+
+    def dispatch_request_email(
+        self,
+        *,
+        run_id: str,
+        operator_email: str,
+        context: Dict[str, Any],
+        email_agent: Any,
+    ) -> str:
+        self.dispatch_calls.append(
+            {
+                "run_id": run_id,
+                "operator": operator_email,
+                "context": dict(context),
+                "email_agent": email_agent,
+            }
+        )
+        return "msg-1"
+
+
+class DummyTelemetry:
+    def __init__(self) -> None:
+        self.events: List[Tuple[str, str, Dict[str, Any]]] = []
+
+    def info(self, event: str, payload: Dict[str, Any]) -> None:
+        self.events.append(("info", event, dict(payload)))
+
+    def warn(self, event: str, payload: Dict[str, Any]) -> None:
+        self.events.append(("warn", event, dict(payload)))
+
+
+class RecordingEvaluator:
+    def __init__(self) -> None:
+        self.calls: List[Dict[str, Any]] = []
+
+    def evaluate(self, context: Dict[str, Any]) -> Tuple[bool, str]:
+        self.calls.append(dict(context))
+        return True, "Low confidence score: 0.5 < 0.9"
+
+
+def test_master_agent_invokes_evaluator_and_persists_reason() -> None:
+    settings = SimpleNamespace(
+        HITL_CONFIDENCE_THRESHOLD=0.9,
+        HITL_OPERATOR_EMAIL="ops@example.com",
+    )
+    agent = MasterWorkflowAgent.__new__(MasterWorkflowAgent)
+    agent.settings = settings
+    agent.communication_backend = SimpleNamespace(email=object())
+    agent.human_agent = DummyHuman()
+    agent.telemetry = DummyTelemetry()
+    agent.hitl_evaluator = RecordingEvaluator()
+
+    message_id = agent.trigger_hitl(
+        "run-eval-1",
+        {"company_domain": "acme.test", "confidence_score": 0.5},
+    )
+
+    assert message_id == "msg-1"
+    assert agent.hitl_evaluator.calls == [
+        {
+            "company_domain": "acme.test",
+            "confidence_score": 0.5,
+            "company_in_crm": None,
+            "attachments_in_crm": None,
+        }
+    ]
+    assert agent.human_agent.persist_calls == [
+        (
+            "run-eval-1",
+            {
+                "company_domain": "acme.test",
+                "confidence_score": 0.5,
+                "hitl_reason": "Low confidence score: 0.5 < 0.9",
+            },
+        )
+    ]
+    assert agent.human_agent.dispatch_calls and agent.human_agent.dispatch_calls[0][
+        "context"
+    ]["hitl_reason"].startswith("Low confidence")
+    assert agent.telemetry.events[0] == (
+        "info",
+        "hitl_required",
+        {"run_id": "run-eval-1", "reason": "Low confidence score: 0.5 < 0.9"},
+    )

--- a/tests/unit/test_reply_parsers.py
+++ b/tests/unit/test_reply_parsers.py
@@ -58,3 +58,17 @@ def test_parse_hitl_reply_detects_change_requests() -> None:
 
     assert decision == "change_requested"
     assert extra == {"website": "example.com", "note": "test"}
+
+
+def test_parse_hitl_reply_handles_disapprove() -> None:
+    decision, extra = parse_hitl_reply("We disapprove of this proposal.")
+
+    assert decision == "declined"
+    assert extra == {}
+
+
+def test_parse_hitl_reply_ignores_embedded_keywords() -> None:
+    decision, extra = parse_hitl_reply("Let's plan an exchange of information.")
+
+    assert decision is None
+    assert extra == {}


### PR DESCRIPTION
## Summary
- integrate the HITLDecisionEvaluator into MasterWorkflowAgent with configurable settings override, reason propagation, and telemetry for HITL requests
- surface evaluator reasons in the HITL request email template and ensure operator email resolution falls back to configured settings
- add a dedicated unit test for the evaluator integration and update existing HITL callback tests for the new flow
- add a configurable HITL_CONFIDENCE_THRESHOLD setting with unit coverage for default and environment overrides

## Testing
- git grep -n "from agents.hitl_decision_evaluator import HITLDecisionEvaluator"
- pytest -o addopts= -q tests/unit/test_master_workflow_agent_hitl_evaluator.py
- pytest -o addopts= -q tests/unit/test_master_workflow_agent_hitl_callbacks.py
- pytest -o addopts= -q tests/unit/test_config_hitl_threshold.py

------
https://chatgpt.com/codex/tasks/task_e_68e666b0802c832ba82e76ec3adea461